### PR TITLE
Add user-agent for initializr requests

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -45,7 +45,7 @@ export namespace Utils {
 
         return await new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
             const urlObj: url.Url = url.parse(targetUrl);
-            const options: Object = Object.assign({ headers: { 'User-Agent': `${getExtensionId()}/${getVersion()}` } }, urlObj);
+            const options: Object = Object.assign({ headers: { 'User-Agent': `vscode/${getVersion()}` } }, urlObj);
             https.get(options, (res: http.IncomingMessage) => {
                 let rawData: string;
                 let ws: fse.WriteStream;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as fse from "fs-extra";
-import { IncomingMessage } from "http";
+import * as http from "http";
 import * as https from "https";
 import * as md5 from "md5";
 import * as os from "os";
@@ -44,7 +44,9 @@ export namespace Utils {
         }
 
         return await new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
-            https.get(url.parse(targetUrl), (res: IncomingMessage) => {
+            const urlObj: url.Url = url.parse(targetUrl);
+            const options: Object = Object.assign({ headers: { 'User-Agent': `${getExtensionId()}/${getVersion()}` } }, urlObj);
+            https.get(options, (res: http.IncomingMessage) => {
                 let rawData: string;
                 let ws: fse.WriteStream;
                 if (readContent) {

--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -9,7 +9,7 @@ export namespace VSCodeUI {
     const terminals: { [id: string]: Terminal } = {};
 
     export function runInTerminal(command: string, options?: ITerminalOptions): void {
-        const defaultOptions: ITerminalOptions = { addNewLine: true, name: "Maven" };
+        const defaultOptions: ITerminalOptions = { addNewLine: true, name: "default" };
         const { addNewLine, name, cwd } = Object.assign(defaultOptions, options);
         if (terminals[name] === undefined) {
             terminals[name] = window.createTerminal({ name });


### PR DESCRIPTION
current format: `ExtensionId`/`version`
e.g.
`User-Agent: vscjava.vscode-spring-initializr/0.2.0`
Related issue: #23 