### PR TITLE
filter dependencies by group & description

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ async function generateProjectRoutine(projectType: string, session?: Session): P
     const manager: DependencyManager = new DependencyManager();
     do {
         current = await vscode.window.showQuickPick(
-            manager.getQuickPickItems(), { ignoreFocusOut: true, placeHolder: STEP3_MESSAGE }
+            manager.getQuickPickItems(), { ignoreFocusOut: true, placeHolder: STEP3_MESSAGE, matchOnDetail: true, matchOnDescription: true }
         );
         if (current && current.itemType === "dependency") {
             manager.toggleDependency(current.id);


### PR DESCRIPTION
Related issue: #26 

Cannot filter by `keywords` if we don't want to show it in the QuickPick item. Currently VSCode only supports matching on rendered text.