### PR TITLE
fix #59: when editing an exisiting project, add base starter if no dependencies are selected.

### DIFF
--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -61,7 +61,7 @@ export class DependencyManager {
     }
 
     public getSelectedDependencies(): IDependency[] {
-        return this.selectedIds.map((id: string) => this.dict[id]);
+        return this.selectedIds.map((id: string) => this.dict[id]).filter(Boolean);
     }
 
     public getUnselectedDependencies(): IDependency[] {

--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as _ from "lodash";
 import { IDependency, IStarters, ITopLevelAttribute } from "./Interfaces";
 import { Utils } from "./Utils";
 import { Versions } from "./Versions";
@@ -26,7 +27,7 @@ export namespace dependencies {
             const rawJSONString: string = await Utils.downloadFile(`${Utils.settings.getServiceUrl()}dependencies?bootVersion=${bootVersion}`, true, { Accept: "application/vnd.initializr.v2.1+json" });
             starters[bootVersion] = JSON.parse(rawJSONString);
         }
-        return starters[bootVersion];
+        return _.cloneDeep(starters[bootVersion]);
     }
 }
 

--- a/src/Routines.ts
+++ b/src/Routines.ts
@@ -186,8 +186,8 @@ export module Routines {
                 vscode.window.showInformationMessage("No changes.");
                 return;
             }
-            const msgRemove: string = (toRemove && toRemove.length) ? `Removing: [${toRemove.map(d => manager.dict[d].name).join(", ")}].` : "";
-            const msgAdd: string = (toAdd && toAdd.length) ? `Adding: [${toAdd.map(d => manager.dict[d].name).join(", ")}].` : "";
+            const msgRemove: string = (toRemove && toRemove.length) ? `Removing: [${toRemove.map(d => manager.dict[d] && manager.dict[d].name).filter(Boolean).join(", ")}].` : "";
+            const msgAdd: string = (toAdd && toAdd.length) ? `Adding: [${toAdd.map(d => manager.dict[d] && manager.dict[d].name).filter(Boolean).join(", ")}].` : "";
             const choice: string = await vscode.window.showWarningMessage(`${msgRemove} ${msgAdd} Proceed?`, "Proceed", "Cancel");
             if (choice !== "Proceed") {
                 TelemetryHelper.finishStep(stepCancel);
@@ -196,6 +196,14 @@ export module Routines {
                 TelemetryHelper.finishStep(stepProceed);
             }
 
+            // add spring-boot-starter if no selected starters
+            if (manager.selectedIds.length === 0) {
+                toAdd.push("spring-boot-starter");
+                starters.dependencies["spring-boot-starter"] = {
+                    groupId: "org.springframework.boot",
+                    artifactId: "spring-boot-starter"
+                };
+            }
             // modify xml object
             const newXml: { project: XmlNode } = getUpdatedPomXml(xml, starters, toRemove, toAdd);
 


### PR DESCRIPTION
When generating a project from Spring Initializr, it always gives you the base starter if no dependencies are selected.

So when we remove all the dependencies during editing, it should add the base starter back.