### PR TITLE
Add a unified entry to generate Maven/Gradle projects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,17 @@
   "activationEvents": [
     "onCommand:spring.initializr.maven-project",
     "onCommand:spring.initializr.gradle-project",
-    "onCommand:spring.initializr.editStarters"
+    "onCommand:spring.initializr.editStarters",
+    "onCommand:spring.initializr.generate"
   ],
   "main": "./out/extension",
   "contributes": {
     "commands": [
+      {
+        "command": "spring.initializr.generate",
+        "title": "Generate a Spring Boot Project",
+        "category": "Spring Initializr"
+      },
       {
         "command": "spring.initializr.maven-project",
         "title": "Generate a Maven Project",
@@ -45,6 +51,10 @@
       "commandPalette": [
         {
           "command": "spring.initializr.editStarters",
+          "when": "never"
+        },
+        {
+          "command": "spring.initializr.generate",
           "when": "never"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,23 +4,47 @@
 "use strict";
 import * as vscode from "vscode";
 import { TelemetryWrapper } from "vscode-extension-telemetry-wrapper";
-
 import { Routines } from "./Routines";
 import { Utils } from "./Utils";
+import { VSCodeUI } from "./VSCodeUI";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     await Utils.loadPackageInfo(context);
     await TelemetryWrapper.initilizeFromJsonFile(context.asAbsolutePath("package.json"));
 
-    ["maven-project", "gradle-project"].forEach((projectType: string) => {
+    ProjectTypes.all().forEach((projectType) => {
         context.subscriptions.push(
-            TelemetryWrapper.registerCommand(`spring.initializr.${projectType}`, async () => await Routines.GenerateProject.run(projectType))
+            TelemetryWrapper.registerCommand(`spring.initializr.${projectType.value}`, async () => await Routines.GenerateProject.run(projectType.value))
         );
     });
 
     context.subscriptions.push(TelemetryWrapper.registerCommand("spring.initializr.editStarters", async (entry: vscode.Uri) => await Routines.EditStarters.run(entry)));
+
+    context.subscriptions.push(TelemetryWrapper.registerCommand("spring.initializr.generate", async () => {
+        const projectType: ProjectType = await VSCodeUI.getQuickPick(ProjectTypes.all(), item => item.title, null, null, {placeHolder: "Select project type."});
+        await vscode.commands.executeCommand(`spring.initializr.${projectType.value}`);
+    }));
 }
 
 export function deactivate(): void {
     // this method is called when your extension is deactivated
+}
+
+type ProjectType = {
+    title: string;
+    value: string;
+};
+
+namespace ProjectTypes {
+    export const MAVEN : ProjectType = {
+        title: "Maven Project",
+        value: "maven-project"
+    };
+    export const GRADLE: ProjectType = {
+        title: "Gradle Project",
+        value: "gradle-project"
+    };
+    export function all(): ProjectType[] {
+        return [MAVEN, GRADLE];
+    }
 }


### PR DESCRIPTION
Add a command `spring.initializr.generate`, it's a unified entry to generate a spring-boot project. It allows users to select different project types (currently available choices: Maven Project, Gradle Project) first, then calls different commands for following steps.

This command is designed to be called by other extensions (via the `vscode.commands.executeCommand` API), so I hide it from the command palette.