### PR TITLE
Upgrade telemetry wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
       "dev": true
     },
     "applicationinsights": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz",
-      "integrity": "sha1-U0Rrgw/o1dYZ7uKieLMdPSUDCSc=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.5.tgz",
+      "integrity": "sha512-T6V4ZyhikGKnuqYGbNz1q5+ORROutUp58UqfLLwHH+X1RkcnEU+gW15kIKWJ8zqGWbilhn6bONJa+T5en642mg==",
       "requires": {
         "diagnostic-channel": "0.2.0",
         "diagnostic-channel-publishers": "0.2.1",
@@ -561,9 +561,9 @@
       }
     },
     "emitter-listener": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz",
-      "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
       "requires": {
         "shimmer": "^1.2.0"
       }
@@ -2417,22 +2417,22 @@
       }
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.18.tgz",
-      "integrity": "sha512-Vw3Sr+dZwl+c6PlsUwrTtCOJkgrmvS3OUVDQGcmpXWAgq9xGq6as0K4pUx+aGqTjzLAESmWSrs6HlJm6J6Khcg==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz",
+      "integrity": "sha512-6/xT3UG6nPcNbBT29RPRJ6uRplI0l1m5ZBX9VXV3XGWrINDvWw2Nk/84xMeWDF1zI1YoPCcjeD0u4gH2OIsrcA==",
       "requires": {
-        "applicationinsights": "1.0.1"
+        "applicationinsights": "1.0.5"
       }
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.3.1.tgz",
-      "integrity": "sha512-92OsAerFwbMf5XzrkWROuehf8tZ25GdLOC7DpvMVXtDO+arFMM0ciBUW9V7KFf5MKCnS+CaxdUvOAV2Ozhgscw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.3.3.tgz",
+      "integrity": "sha512-UmPiLVv+Ejpx9bv9dsaJJ0i+CEClsjvgSyAHiFUBZazmcGid9U/1Btj2HhCjqcRSKmLR/DWsHOgV73DTafblWw==",
       "requires": {
         "continuation-local-storage": "^3.2.1",
         "fs-extra": "^5.0.0",
         "uuid": "^3.1.0",
-        "vscode-extension-telemetry": "^0.0.18"
+        "vscode-extension-telemetry": "^0.0.22"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "lodash": "^4.17.5",
     "md5": "^2.2.1",
     "unzip-stream": "^0.3.0",
-    "vscode-extension-telemetry-wrapper": "^0.3.1",
+    "vscode-extension-telemetry-wrapper": "^0.3.3",
     "xml2js": "^0.4.19"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 import * as vscode from "vscode";
-import { initializeFromJsonFile, instrumentOperation, TelemetryWrapper } from "vscode-extension-telemetry-wrapper";
+import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentOperation, TelemetryWrapper } from "vscode-extension-telemetry-wrapper";
 import { Routines } from "./Routines";
 import { Utils } from "./Utils";
 import { VSCodeUI } from "./VSCodeUI";
@@ -29,8 +29,8 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     }));
 }
 
-export function deactivate(): void {
-    // this method is called when your extension is deactivated
+export async function deactivate(): Promise<void> {
+    await disposeTelemetryWrapper();
 }
 
 type ProjectType = {


### PR DESCRIPTION
This PR:
* upgrades version of vscode-extension-telemetry-wrapper to v0.3.3 (which uses the latest vscode-extension-telemetry@0.0.22). See issue #81 .
* disposes the reporter (to send out all queued events) when the extension is deactivated.

