### PR TITLE
Allow to set multiple default service URLs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
             "string",
             "array"
           ],
-          "pattern": "https?://.*",
+          "pattern": "https?://.+",
           "scope": "window",
           "description": "Spring Initializr Service URL(s)."
         },

--- a/package.json
+++ b/package.json
@@ -74,10 +74,13 @@
       "properties": {
         "spring.initializr.serviceUrl": {
           "default": "https://start.spring.io/",
-          "type": "string",
+          "type": [
+            "string",
+            "array"
+          ],
           "pattern": "https?://.*",
           "scope": "window",
-          "description": "Spring Initializr Service URL."
+          "description": "Spring Initializr Service URL(s)."
         },
         "spring.initializr.defaultLanguage": {
           "default": "",

--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { QuickPickItem } from "vscode";
-import { getAvailableDependencies, IDependency } from "./model";
+import { IDependency, ServiceManager } from "./model";
 import { readFileFromExtensionRoot, writeFileToExtensionRoot } from "./Utils";
 
 const PLACEHOLDER: string = "";
@@ -30,9 +30,9 @@ class DependencyManager {
         this.lastselected = idList;
     }
 
-    public async getQuickPickItems(bootVersion: string, options?: { hasLastSelected: boolean }): Promise<Array<QuickPickItem & IDependenciesItem>> {
+    public async getQuickPickItems(manager: ServiceManager, bootVersion: string, options?: { hasLastSelected: boolean }): Promise<Array<QuickPickItem & IDependenciesItem>> {
         if (this.dependencies.length === 0) {
-            await this.initialize(await getAvailableDependencies(bootVersion));
+            await this.initialize(await manager.getAvailableDependencies(bootVersion));
         }
         const ret: Array<QuickPickItem & IDependenciesItem> = [];
         if (this.selectedIds.length === 0) {

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -132,10 +132,6 @@ export function buildXmlContent(obj: any, options?: {}): string {
     return new xml2js.Builder(opts).buildObject(obj);
 }
 
-export function getServiceUrl(): string {
-    return vscode.workspace.getConfiguration("spring.initializr").get<string>("serviceUrl");
-}
-
 export async function getTargetPomXml(): Promise<vscode.Uri> {
     if (vscode.window.activeTextEditor) {
         const fsPath: string = vscode.window.activeTextEditor.document.fileName;

--- a/src/handler/EditStartersHandler.ts
+++ b/src/handler/EditStartersHandler.ts
@@ -12,18 +12,20 @@ import {
     DependencyNode,
     getBootVersion,
     getDependencyNodes,
-    getStarters,
     IBom,
     IMavenId,
     IRepository,
     IStarters,
     removeDependencyNode,
     RepositoryNode,
+    ServiceManager,
     XmlNode,
 } from "../model";
 import { buildXmlContent, readXmlContent } from "../Utils";
 
 export class EditStartersHandler {
+    private serviceUrl: string;
+    private manager: ServiceManager;
 
     public async run(entry: vscode.Uri): Promise<void> {
         const deps: string[] = []; // gid:aid
@@ -42,12 +44,17 @@ export class EditStartersHandler {
             deps.push(`${elem.groupId[0]}:${elem.artifactId[0]}`);
         });
 
+        this.serviceUrl = await specifyServiceUrl();
+        if (this.serviceUrl === undefined) {
+            return;
+        }
+        this.manager = new ServiceManager(this.serviceUrl);
         // [interaction] Step: Dependencies, with pre-selected deps
         const starters: IStarters = await vscode.window.withProgress<IStarters>(
             { location: vscode.ProgressLocation.Window },
             async (p) => {
                 p.report({ message: `Fetching metadata for version ${bootVersion} ...` });
-                return await getStarters(bootVersion);
+                return await this.manager.getStarters(bootVersion);
             },
         );
 
@@ -63,7 +70,7 @@ export class EditStartersHandler {
         let current: IDependenciesItem = null;
         do {
             current = await vscode.window.showQuickPick(
-                dependencyManager.getQuickPickItems(bootVersion),
+                dependencyManager.getQuickPickItems(this.manager, bootVersion),
                 {
                     ignoreFocusOut: true,
                     matchOnDescription: true,
@@ -136,4 +143,15 @@ function getUpdatedPomXml(xml: any, starters: IStarters, toRemove: string[], toA
 
     });
     return ret;
+}
+
+async function specifyServiceUrl(): Promise<string> {
+    const configValue = vscode.workspace.getConfiguration("spring.initializr").get<string | string[]>("serviceUrl");
+    if (typeof configValue === "string") {
+        return configValue;
+    } else if (typeof configValue === "object" && configValue instanceof Array) {
+        return await vscode.window.showQuickPick(configValue, { ignoreFocusOut: true, placeHolder: "Select the service URL." });
+    } else {
+        return "https://start.spring.io/";
+    }
 }

--- a/src/handler/EditStartersHandler.ts
+++ b/src/handler/EditStartersHandler.ts
@@ -22,6 +22,7 @@ import {
     XmlNode,
 } from "../model";
 import { buildXmlContent, readXmlContent } from "../Utils";
+import { specifyServiceUrl } from "./utils";
 
 export class EditStartersHandler {
     private serviceUrl: string;
@@ -143,15 +144,4 @@ function getUpdatedPomXml(xml: any, starters: IStarters, toRemove: string[], toA
 
     });
     return ret;
-}
-
-async function specifyServiceUrl(): Promise<string> {
-    const configValue = vscode.workspace.getConfiguration("spring.initializr").get<string | string[]>("serviceUrl");
-    if (typeof configValue === "string") {
-        return configValue;
-    } else if (typeof configValue === "object" && configValue instanceof Array) {
-        return await vscode.window.showQuickPick(configValue, { ignoreFocusOut: true, placeHolder: "Select the service URL." });
-    } else {
-        return "https://start.spring.io/";
-    }
 }

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -11,6 +11,7 @@ import { OperationCanceledError } from "../Errors";
 import { IValue, ServiceManager } from "../model";
 import { artifactIdValidation, downloadFile, groupIdValidation } from "../Utils";
 import { getFromInputBox, openDialogForFolder } from "../Utils/VSCodeUI";
+import { specifyServiceUrl } from "./utils";
 
 export class GenerateProjectHandler {
     private serviceUrl: string;
@@ -95,17 +96,6 @@ export class GenerateProjectHandler {
             `dependencies=${this.dependencies.id}`,
         ];
         return `${this.serviceUrl}/starter.zip?${params.join("&")}`;
-    }
-}
-
-async function specifyServiceUrl(): Promise<string> {
-    const configValue = vscode.workspace.getConfiguration("spring.initializr").get<string | string[]>("serviceUrl");
-    if (typeof configValue === "string") {
-        return configValue;
-    } else if (typeof configValue === "object" && configValue instanceof Array) {
-        return await vscode.window.showQuickPick(configValue, { ignoreFocusOut: true, placeHolder: "Select the service URL." });
-    } else {
-        return "https://start.spring.io/";
     }
 }
 

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -9,7 +9,10 @@ export async function specifyServiceUrl(): Promise<string> {
     const configValue = vscode.workspace.getConfiguration("spring.initializr").get<string | string[]>("serviceUrl");
     if (typeof configValue === "string") {
         return configValue;
-    } else if (typeof configValue === "object" && configValue instanceof Array) {
+    } else if (typeof configValue === "object" && configValue instanceof Array && configValue.length > 0) {
+        if (configValue.length === 1) {
+            return configValue[0];
+        }
         return await vscode.window.showQuickPick(configValue, { ignoreFocusOut: true, placeHolder: "Select the service URL." });
     } else {
         return DEFAULT_SERVICE_URL;

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+
+const DEFAULT_SERVICE_URL: string = "https://start.spring.io/";
+
+export async function specifyServiceUrl(): Promise<string> {
+    const configValue = vscode.workspace.getConfiguration("spring.initializr").get<string | string[]>("serviceUrl");
+    if (typeof configValue === "string") {
+        return configValue;
+    } else if (typeof configValue === "object" && configValue instanceof Array) {
+        return await vscode.window.showQuickPick(configValue, { ignoreFocusOut: true, placeHolder: "Select the service URL." });
+    } else {
+        return DEFAULT_SERVICE_URL;
+    }
+}

--- a/src/model/ServiceManager.ts
+++ b/src/model/ServiceManager.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as _ from "lodash";
+import { IDependency, IStarters, ITopLevelAttribute } from ".";
+import { downloadFile } from "../Utils";
+import { matchRange } from "../Utils/VersionHelper";
+
+export class ServiceManager {
+    private static isCompatible(dep: IDependency, bootVersion: string): boolean {
+        if (bootVersion && dep && dep.versionRange) {
+            return matchRange(bootVersion, dep.versionRange);
+        } else {
+            return true;
+        }
+    }
+
+    private serviceUrl: string;
+    private overview: {
+        dependencies: ITopLevelAttribute,
+        // tslint:disable-next-line:no-reserved-keywords
+        type: ITopLevelAttribute,
+        packaging: ITopLevelAttribute,
+        javaVersion: ITopLevelAttribute,
+        language: ITopLevelAttribute,
+        bootVersion: ITopLevelAttribute,
+    };
+    private starters: { [bootVersion: string]: IStarters } = {};
+
+    constructor(serviceUrl: string) {
+        this.serviceUrl = serviceUrl;
+    }
+
+    public async getStarters(bootVersion: string): Promise<IStarters> {
+        if (!this.starters[bootVersion]) {
+            const rawJSONString: string = await downloadFile(`${this.serviceUrl}dependencies?bootVersion=${bootVersion}`, true, { Accept: "application/vnd.initializr.v2.1+json" });
+            this.starters[bootVersion] = JSON.parse(rawJSONString);
+        }
+        return _.cloneDeep(this.starters[bootVersion]);
+    }
+
+    public async getBootVersions(): Promise<any[]> {
+        if (!this.overview) {
+            await this.update();
+        }
+        if (!this.overview.bootVersion) {
+            return [];
+        } else {
+            return this.overview.bootVersion.values.filter(x => x.id === this.overview.bootVersion.default)
+                .concat(this.overview.bootVersion.values.filter(x => x.id !== this.overview.bootVersion.default));
+        }
+    }
+
+    public async getAvailableDependencies(bootVersion: string): Promise<IDependency[]> {
+        if (!this.overview) {
+            await this.update();
+        }
+        if (!this.overview.dependencies) {
+            return [];
+        } else {
+            const ret: IDependency[] = [];
+            for (const grp of this.overview.dependencies.values) {
+                const group: string = grp.name;
+                ret.push(...grp.values.filter(dep => ServiceManager.isCompatible(dep, bootVersion)).map(dep => Object.assign({ group }, dep)));
+            }
+            return ret;
+        }
+    }
+
+    private async update(): Promise<void> {
+        const rawJSONString: string = await downloadFile(this.serviceUrl, true, { Accept: "application/vnd.initializr.v2.1+json" });
+        this.overview = JSON.parse(rawJSONString);
+    }
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,74 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as _ from "lodash";
-import { downloadFile, getServiceUrl } from "../Utils";
-import { matchRange } from "../Utils/VersionHelper";
-import { IDependency, IStarters, ITopLevelAttribute } from "./Interfaces";
-
-let overview: {
-    dependencies: ITopLevelAttribute,
-    // tslint:disable-next-line:no-reserved-keywords
-    type: ITopLevelAttribute,
-    packaging: ITopLevelAttribute,
-    javaVersion: ITopLevelAttribute,
-    language: ITopLevelAttribute,
-    bootVersion: ITopLevelAttribute,
-};
-
-const starters: { [bootVersion: string]: IStarters } = {};
-
-export async function getStarters(bootVersion: string): Promise<IStarters> {
-    if (!starters[bootVersion]) {
-        const rawJSONString: string = await downloadFile(`${getServiceUrl()}dependencies?bootVersion=${bootVersion}`, true, { Accept: "application/vnd.initializr.v2.1+json" });
-        starters[bootVersion] = JSON.parse(rawJSONString);
-    }
-    return _.cloneDeep(starters[bootVersion]);
-}
-
-export async function getBootVersions(): Promise<any[]> {
-    if (!overview) {
-        await update();
-    }
-    if (!overview.bootVersion) {
-        return [];
-    } else {
-        return overview.bootVersion.values.filter(x => x.id === overview.bootVersion.default)
-            .concat(overview.bootVersion.values.filter(x => x.id !== overview.bootVersion.default));
-    }
-}
-
-export async function getAvailableDependencies(bootVersion: string): Promise<IDependency[]> {
-    if (!overview) {
-        await update();
-    }
-    if (!overview.dependencies) {
-        return [];
-    } else {
-        const ret: IDependency[] = [];
-        for (const grp of overview.dependencies.values) {
-            const group: string = grp.name;
-            ret.push(...grp.values.filter(dep => isCompatible(dep, bootVersion)).map(dep => Object.assign({ group }, dep)));
-        }
-        return ret;
-    }
-}
-
-function isCompatible(dep: IDependency, bootVersion: string): boolean {
-    if (bootVersion && dep && dep.versionRange) {
-        return matchRange(bootVersion, dep.versionRange);
-    } else {
-        return true;
-    }
-}
-
-async function update(): Promise<void> {
-    const rawJSONString: string = await downloadFile(getServiceUrl(), true, { Accept: "application/vnd.initializr.v2.1+json" });
-    overview = JSON.parse(rawJSONString);
-}
-
 export * from "./Interfaces";
 export * from "./pomxml/BomNode";
 export * from "./pomxml/DependencyNode";
 export * from "./pomxml/PomXml";
 export * from "./pomxml/RepositoryNode";
+export { ServiceManager } from "./ServiceManager";


### PR DESCRIPTION
This PR enables the feature to set multiple service URL in settings. 
1. Type of the config is changed to `string` or `array of strings`
  * if `string`, fallback to previous behavior.
  * if `array`, it first require users to pick on from the list. 
2. About the code changes, as different services has different results, now I added a new class `ServiceManager` to handle stuffs like getting available versions, starters, etc. 