### PR TITLE
Fix NPE in last selected dependency

### DIFF
--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -37,7 +37,10 @@ class DependencyManager {
         const ret: Array<QuickPickItem & IDependenciesItem> = [];
         if (this.selectedIds.length === 0) {
             if (options && options.hasLastSelected && this.lastselected) {
-                ret.push(this.genLastSelectedItem(this.lastselected));
+                const item = this.genLastSelectedItem(this.lastselected);
+                if (item) {
+                    ret.push(item);
+                }
             }
         }
         ret.push({


### PR DESCRIPTION
`genLastSelectedItem` is possible to return `null`. Then the QuickPick cannot render null, and throws an exception when access `label` of `null`. 