### PR TITLE
Specify Java version; Load default Java version;

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ ext install vscode-spring-initializr
   // Default value for Artifact Id.
   "spring.initializr.defaultArtifactId": "demo",
 
+  // Default value for Name.
+  "spring.initializr.defaultName": "demo",
+
   // Default value for Group Id.
   "spring.initializr.defaultGroupId": "com.example",
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ ext install vscode-spring-initializr
   // Default value for Artifact Id.
   "spring.initializr.defaultArtifactId": "demo",
 
-  // Default value for Name.
-  "spring.initializr.defaultName": "demo",
-
   // Default value for Group Id.
   "spring.initializr.defaultGroupId": "com.example",
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Spring Initializr is a lightweight extension to quickly generate a Spring Boot p
 ## Feature List
 
 - Generate a Maven/Gradle Spring Boot project 
-- Customize configurations for a new project (language, group id, artifact id, boot version and dependencies)
+- Customize configurations for a new project (language, Java version, group id, artifact id, boot version and dependencies)
 - Search for dependencies
 - Quickstart with last settings
 - Edit Spring Boot dependencies of an existing Spring Boot project
@@ -43,6 +43,9 @@ ext install vscode-spring-initializr
 ```
   // Default language.
   "spring.initializr.defaultLanguage": "Java",
+
+  // Default Java version.
+  "spring.initializr.defaultJavaVersion": "11",
 
   // Default value for Artifact Id.
   "spring.initializr.defaultArtifactId": "demo",

--- a/TestPlan.md
+++ b/TestPlan.md
@@ -64,13 +64,6 @@ After that, verify `build.gradle` instead of `pom.xml`.
 1. Verify:
     1. `GroupId` and `ArtifactId` are filled by the specified default values.
 
-### Default value of Name.
-1. Open `User settings` in VS Code.
-2. Change values of entry `spring.initializr.defaultName`.
-3. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
-4. Verify:
-    1. `Name` is filled by the specified default value.
-
 ### Default value of language.
 1. Open `User settings` in VS Code.
 2. Change values of entry `spring.initializr.defaultLanguage` to `""`.

--- a/TestPlan.md
+++ b/TestPlan.md
@@ -74,6 +74,16 @@ After that, verify `build.gradle` instead of `pom.xml`.
 5. Verify:
     1. It skips the step to select language, and directly uses the value you set.
 
+### Default value of Java version.
+1. Open `User settings` in VS Code.
+2. Change values of entry `spring.initializr.defaultJavaVersion` to `""`.
+3. Verify:
+    1. It allows to select Java version during generating the project.
+    2. Open the generated project, the Java version matches what you selected.
+4. Change values of entry `spring.initializr.defaultJavaVersion` to `"1.8"`.
+5. Verify:
+    1. It skips the step to select Java version, and directly uses the value you set.
+
 ### Default value of packaging.
 1. Open `User settings` in VS Code.
 2. Change values of entry `spring.initializr.defaultPackaging` to `""`.

--- a/TestPlan.md
+++ b/TestPlan.md
@@ -4,39 +4,39 @@
 ### Quickstart with dependency search
 
 1. Open VS Code without opening any folder.
-1. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
-1. Input a invalid `Group Id`, verify:
+2. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
+3. Input a invalid `Group Id`, verify:
     1. It doesn't pass the validation.
-1. Input a valid `Group Id`, e.g. `com.microsoft.example`, press `<Enter>`.
-1. Input a invalid `Artifact Id`, verify:
+4. Input a valid `Group Id`, e.g. `com.microsoft.example`, press `<Enter>`.
+5. Input a invalid `Artifact Id`, verify:
     1. It doesn't pass the validation.
-1. Input a valid `Artifact Id`, e.g. `sample-artifact`, press `Enter`.
-1. Select a version, verify:
+6. Input a valid `Artifact Id`, e.g. `sample-artifact`, press `Enter`.
+7. Select a version, verify:
     1. It lists compatible dependencies for the specified version you selected.
-1. Select some dependencies, verify:
+8. Select some dependencies, verify:
     1. Selected dependency is entitled by a check mark, and is placed ahead of the dependency list.
-    1. Can cancel the selection by pressing `<Enter>` on a selected dependency.
-    1. The first entry is `Selected # dependency(ies)`, and `#` is the number of seleted entries.
-1. Press `<Enter>` on `Selected # dependency(ies)`, verify:
+    2. Can cancel the selection by pressing `<Enter>` on a selected dependency.
+    3. The first entry is `Selected # dependency(ies)`, and `#` is the number of seleted entries.
+9. Press `<Enter>` on `Selected # dependency(ies)`, verify:
     1. It pops up a directory-selection dialog.
-1. Choose a target folder, verify:
+10. Choose a target folder, verify:
     1. During generating, it shows process in status bar.
-    1. After the process disappear, it shows a information message box on the top.
-1. Click `Open it`, verify:
+    2. After the process disappear, it shows a information message box on the top.
+11. Click `Open it`, verify:
     1. It opens the project in current window.
-1. Open `pom.xml` in root folder, verify:
+12. Open `pom.xml` in root folder, verify:
     1. `Group Id` and `Artifact Id` are correct.
-    1. Selected dependencies are added under `<dependencies>` tag.
-1. Verify the folder structure is organized as `Group Id`.
+    2. Selected dependencies are added under `<dependencies>` tag.
+13. Verify the folder structure is organized as `Group Id`.
 
 ### Quickstart with last settings
 
 1. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
-1. Input a valid `Group Id`, e.g. `com.microsoft.example`, press `<Enter>`.
-1. Input a valid `Artifact Id`, e.g. `sample-artifact`, press `Enter`.
-1. Press `<Enter>` on `Use Last Settings`, verify:
+2. Input a valid `Group Id`, e.g. `com.microsoft.example`, press `<Enter>`.
+3. Input a valid `Artifact Id`, e.g. `sample-artifact`, press `Enter`.
+4. Press `<Enter>` on `Use Last Settings`, verify:
     1. The dialog shows the dependeny(ies) name in last settings.
-1. Choose a target folder, open it and verify the `pom.xml`, using same steps above. 
+5. Choose a target folder, open it and verify the `pom.xml`, using same steps above. 
 
 
 ## Generate a Gradle Project
@@ -47,21 +47,21 @@ After that, verify `build.gradle` instead of `pom.xml`.
 
 ## Customized Spring Initializr Service URL
 1. Open `User settings` in VS Code.
-1. Change value of entry `spring.initializr.serviceUrl`, e.g. "https://start.cfapps.io/", or [run the service locally](https://github.com/spring-io/initializr#running-the-app-locally) (if the previous one doesn't work). 
-1. Verify:
+2. Change value of entry `spring.initializr.serviceUrl`, e.g. "https://start.cfapps.io/", or [run the service locally](https://github.com/spring-io/initializr#running-the-app-locally) (if the previous one doesn't work). 
+3. Verify:
     1. Can generate a project from the specified service URL.
-1. Change value of entry `spring.initializr.serviceUrl` to an array, e.g. ["https://start.cfapps.io/", "https://start.spring.io/"]
-1. Verify:
+4. Change value of entry `spring.initializr.serviceUrl` to an array, e.g. ["https://start.cfapps.io/", "https://start.spring.io/"]
+5. Verify:
     1. Before generating a project/editing starters, it requires users to select one from the list.
-    1. Can generate a project from the selected service URL.
+    2. Can generate a project from the selected service URL.
 
 
 ## Default Values
 ### Default value of GroupId and ArtifactId.
 1. Open `User settings` in VS Code.
-1. Change values of entry `spring.initializr.defaultGroupId`, `spring.initializr.defaultArtifactId`.
-1. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
-1. Verify:
+2. Change values of entry `spring.initializr.defaultGroupId`, `spring.initializr.defaultArtifactId`.
+3. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
+4. Verify:
     1. `GroupId` and `ArtifactId` are filled by the specified default values.
 
 ### Default value of language.

--- a/TestPlan.md
+++ b/TestPlan.md
@@ -64,6 +64,13 @@ After that, verify `build.gradle` instead of `pom.xml`.
 1. Verify:
     1. `GroupId` and `ArtifactId` are filled by the specified default values.
 
+### Default value of Name.
+1. Open `User settings` in VS Code.
+2. Change values of entry `spring.initializr.defaultName`.
+3. Open `Command Palette`, execute command `Spring Initializr: Generate a Maven Project`.
+4. Verify:
+    1. `Name` is filled by the specified default value.
+
 ### Default value of language.
 1. Open `User settings` in VS Code.
 2. Change values of entry `spring.initializr.defaultLanguage` to `""`.

--- a/package.json
+++ b/package.json
@@ -120,12 +120,6 @@
           "scope": "window",
           "description": "Default value for Artifact Id."
         },
-        "spring.initializr.defaultName": {
-          "default": "demo",
-          "type": "string",
-          "scope": "window",
-          "description": "Default value for Name (Application name)."
-        },
         "spring.initializr.defaultPackaging": {
           "default": "JAR",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,12 @@
           "scope": "window",
           "description": "Default value for Artifact Id."
         },
+        "spring.initializr.defaultName": {
+          "default": "demo",
+          "type": "string",
+          "scope": "window",
+          "description": "Default value for Name (Application name)."
+        },
         "spring.initializr.defaultPackaging": {
           "default": "JAR",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,18 @@
           "scope": "window",
           "description": "Default language."
         },
+        "spring.initializr.defaultJavaVersion": {
+          "default": "",
+          "type": "string",
+          "enum": [
+            "",
+            "1.8",
+            "11",
+            "14"
+          ],
+          "scope": "window",
+          "description": "Default Java version."
+        },
         "spring.initializr.defaultGroupId": {
           "default": "com.example",
           "type": "string",

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -114,10 +114,6 @@ export function artifactIdValidation(value: string): string {
     return (/^[a-z_][a-z0-9_]*(-[a-z_][a-z0-9_]*)*$/.test(value)) ? null : "Invalid Artifact Id";
 }
 
-export function nameValidation(value: string): string {
-    return (/^[a-z_][a-z0-9_]*(-[a-z_][a-z0-9_]*)*$/.test(value)) ? null : "Invalid Name";
-}
-
 export async function readXmlContent(xml: string, options?: {}): Promise<any> {
     const opts: {} = Object.assign({ explicitArray: true }, options);
     return new Promise<{}>(

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -114,6 +114,10 @@ export function artifactIdValidation(value: string): string {
     return (/^[a-z_][a-z0-9_]*(-[a-z_][a-z0-9_]*)*$/.test(value)) ? null : "Invalid Artifact Id";
 }
 
+export function nameValidation(value: string): string {
+    return (/^[a-z_][a-z0-9_]*(-[a-z_][a-z0-9_]*)*$/.test(value)) ? null : "Invalid Name";
+}
+
 export async function readXmlContent(xml: string, options?: {}): Promise<any> {
     const opts: {} = Object.assign({ explicitArray: true }, options);
     return new Promise<{}>(

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -128,7 +128,7 @@ async function specifyJavaVersion(): Promise<string> {
     let javaVersion: string = vscode.workspace.getConfiguration("spring.initializr").get<string>("defaultJavaVersion");
     if (!javaVersion) {
         javaVersion = await vscode.window.showQuickPick(
-            ["1.8", "11", "14"],
+            ["11", "1.8", "14"],
             { ignoreFocusOut: true, placeHolder: "Specify Java version." },
         );
     }

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -9,7 +9,7 @@ import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wr
 import { DependencyManager, IDependenciesItem } from "../DependencyManager";
 import { OperationCanceledError } from "../Errors";
 import { IValue, serviceManager } from "../model";
-import { artifactIdValidation, nameValidation, downloadFile, groupIdValidation } from "../Utils";
+import { artifactIdValidation, downloadFile, groupIdValidation } from "../Utils";
 import { getFromInputBox, openDialogForFolder } from "../Utils/VSCodeUI";
 import { BaseHandler } from "./BaseHandler";
 import { specifyServiceUrl } from "./utils";
@@ -18,7 +18,6 @@ export class GenerateProjectHandler extends BaseHandler {
     private serviceUrl: string;
     private artifactId: string;
     private groupId: string;
-    private name: string;
     private language: string;
     private javaVersion: string;
     private projectType: "maven-project" | "gradle-project";
@@ -57,10 +56,6 @@ export class GenerateProjectHandler extends BaseHandler {
         // Step: Artifact Id
         this.artifactId = await instrumentOperationStep(operationId, "ArtifactId", specifyArtifactId)();
         if (this.artifactId === undefined) { throw new OperationCanceledError("ArtifactId not specified."); }
-
-        // Step: Name
-        this.name = await instrumentOperationStep(operationId, "Name", specifyName)();
-        if (this.name === undefined) { throw new OperationCanceledError("Name not specified."); }
 
         // Step: Packaging
         this.packaging = await instrumentOperationStep(operationId, "Packaging", specifyPackaging)();
@@ -103,7 +98,7 @@ export class GenerateProjectHandler extends BaseHandler {
             `javaVersion=${this.javaVersion}`,
             `groupId=${this.groupId}`,
             `artifactId=${this.artifactId}`,
-            `name=${this.name}`,
+            `name=${this.artifactId}`,
             `packaging=${this.packaging}`,
             `bootVersion=${this.bootVersion}`,
             `baseDir=${this.artifactId}`,
@@ -152,16 +147,6 @@ async function specifyArtifactId(): Promise<string> {
         prompt: "Input Artifact Id for your project.",
         validateInput: artifactIdValidation,
         value: defaultArtifactId,
-    });
-}
-
-async function specifyName(): Promise<string> {
-    const defaultName: string = vscode.workspace.getConfiguration("spring.initializr").get<string>("defaultName");
-    return await getFromInputBox({
-        placeHolder: "e.g. demo (will turn into DemoApplication class - mostly the same as ArtifactId)",
-        prompt: "Input project name.",
-        validateInput: nameValidation,
-        value: defaultName,
     });
 }
 

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -19,6 +19,7 @@ export class GenerateProjectHandler extends BaseHandler {
     private artifactId: string;
     private groupId: string;
     private language: string;
+    private javaVersion: string;
     private projectType: "maven-project" | "gradle-project";
     private packaging: string;
     private bootVersion: string;
@@ -43,6 +44,10 @@ export class GenerateProjectHandler extends BaseHandler {
         // Step: language
         this.language = await instrumentOperationStep(operationId, "Language", specifyLanguage)();
         if (this.language === undefined) { throw new OperationCanceledError("Language not specified."); }
+
+        // Step: java version
+        this.javaVersion = await instrumentOperationStep(operationId, "JavaVersion", specifyJavaVersion)();
+        if (this.javaVersion === undefined) { throw new OperationCanceledError("Java version not specified."); }
 
         // Step: Group Id
         this.groupId = await instrumentOperationStep(operationId, "GroupId", specifyGroupId)();
@@ -90,6 +95,7 @@ export class GenerateProjectHandler extends BaseHandler {
         const params: string[] = [
             `type=${this.projectType}`,
             `language=${this.language}`,
+            `javaVersion=${this.javaVersion}`,
             `groupId=${this.groupId}`,
             `artifactId=${this.artifactId}`,
             `packaging=${this.packaging}`,
@@ -110,6 +116,17 @@ async function specifyLanguage(): Promise<string> {
         );
     }
     return language && language.toLowerCase();
+}
+
+async function specifyJavaVersion(): Promise<string> {
+    let javaVersion: string = vscode.workspace.getConfiguration("spring.initializr").get<string>("defaultJavaVersion");
+    if (!javaVersion) {
+        javaVersion = await vscode.window.showQuickPick(
+            ["1.8", "11", "14"],
+            { ignoreFocusOut: true, placeHolder: "Specify Java version." },
+        );
+    }
+    return javaVersion;
 }
 
 async function specifyGroupId(): Promise<string> {


### PR DESCRIPTION
Pulling a "Specify Java version" feature.
It is simple to change the Java version when the project is created (issue 136 is closed with that comment - https://github.com/microsoft/vscode-spring-initializr/issues/136 ), but I added this feature since VSCode is turning to use Java 11, so it is helpful to choose Java version when creating the project.