### PR TITLE
Reset default value of groupId/artifactId when a new creating project command is called

### DIFF
--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -37,8 +37,8 @@ export class GenerateProjectHandler extends BaseHandler {
         const projectMetadata: IProjectMetadata = {
             pickSteps: []
         };
-        SpecifyArtifactIdStep.getInstance().resetLastInput();
-        SpecifyGroupIdStep.getInstance().resetLastInput();
+        SpecifyArtifactIdStep.getInstance().resetDefaultInput();
+        SpecifyGroupIdStep.getInstance().resetDefaultInput();
         while (step !== undefined) {
             step = await step.execute(operationId, projectMetadata);
         }

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -12,6 +12,8 @@ import { openDialogForFolder } from "../Utils/VSCodeUI";
 import { BaseHandler } from "./BaseHandler";
 import { IProjectMetadata } from "./IProjectMetadata";
 import { IStep } from "./IStep";
+import { SpecifyArtifactIdStep } from "./SpecifyArtifactIdStep";
+import { SpecifyGroupIdStep } from "./SpecifyGroupIdStep";
 import { SpecifyServiceUrlStep } from "./SpecifyServiceUrlStep";
 
 export class GenerateProjectHandler extends BaseHandler {
@@ -35,6 +37,8 @@ export class GenerateProjectHandler extends BaseHandler {
         const projectMetadata: IProjectMetadata = {
             pickSteps: []
         };
+        SpecifyArtifactIdStep.getInstance().resetLastInput();
+        SpecifyGroupIdStep.getInstance().resetLastInput();
         while (step !== undefined) {
             step = await step.execute(operationId, projectMetadata);
         }

--- a/src/handler/SpecifyArtifactIdStep.ts
+++ b/src/handler/SpecifyArtifactIdStep.ts
@@ -16,22 +16,22 @@ export class SpecifyArtifactIdStep implements IStep {
 
     private static specifyArtifactIdStep: SpecifyArtifactIdStep = new SpecifyArtifactIdStep();
 
-    private lastInput: string;
+    private defaultInput: string;
 
     constructor() {
-        this.resetLastInput();
+        this.resetDefaultInput();
     }
 
-    public getLastInput(): string {
-        return this.lastInput;
+    public getDefaultInput(): string {
+        return this.defaultInput;
     }
 
-    public setLastInput(lastInput: string): void {
-        this.lastInput = lastInput;
+    public setDefaultInput(defaultInput: string): void {
+        this.defaultInput = defaultInput;
     }
 
-    public resetLastInput(): void {
-        this.lastInput = workspace.getConfiguration("spring.initializr").get<string>("defaultArtifactId");
+    public resetDefaultInput(): void {
+        this.defaultInput = workspace.getConfiguration("spring.initializr").get<string>("defaultArtifactId");
     }
 
     public getNextStep(): IStep | undefined {
@@ -51,7 +51,7 @@ export class SpecifyArtifactIdStep implements IStep {
             pickStep: SpecifyArtifactIdStep.getInstance(),
             placeholder: "e.g. demo",
             prompt: "Input Artifact Id for your project.",
-            defaultValue: SpecifyArtifactIdStep.getInstance().lastInput
+            defaultValue: SpecifyArtifactIdStep.getInstance().defaultInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/SpecifyArtifactIdStep.ts
+++ b/src/handler/SpecifyArtifactIdStep.ts
@@ -18,12 +18,20 @@ export class SpecifyArtifactIdStep implements IStep {
 
     private lastInput: string;
 
+    constructor() {
+        this.resetLastInput();
+    }
+
     public getLastInput(): string {
         return this.lastInput;
     }
 
     public setLastInput(lastInput: string): void {
         this.lastInput = lastInput;
+    }
+
+    public resetLastInput(): void {
+        this.lastInput = workspace.getConfiguration("spring.initializr").get<string>("defaultArtifactId");
     }
 
     public getNextStep(): IStep | undefined {
@@ -38,13 +46,12 @@ export class SpecifyArtifactIdStep implements IStep {
     }
 
     private async specifyArtifactId(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const defaultArtifactId: string = workspace.getConfiguration("spring.initializr").get<string>("defaultArtifactId");
         const inputMetaData: IInputMetaData = {
             metadata: projectMetadata,
             pickStep: SpecifyArtifactIdStep.getInstance(),
             placeholder: "e.g. demo",
             prompt: "Input Artifact Id for your project.",
-            defaultValue: defaultArtifactId
+            defaultValue: SpecifyArtifactIdStep.getInstance().lastInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/SpecifyGroupIdStep.ts
+++ b/src/handler/SpecifyGroupIdStep.ts
@@ -16,22 +16,22 @@ export class SpecifyGroupIdStep implements IStep {
 
     private static specifyGroupIdStep: SpecifyGroupIdStep = new SpecifyGroupIdStep();
 
-    private lastInput: string;
+    private defaultInput: string;
 
     constructor() {
-        this.resetLastInput();
+        this.resetDefaultInput();
     }
 
-    public getLastInput(): string {
-        return this.lastInput;
+    public getDefaultInput(): string {
+        return this.defaultInput;
     }
 
-    public setLastInput(lastInput: string): void {
-        this.lastInput = lastInput;
+    public setDefaultInput(defaultInput: string): void {
+        this.defaultInput = defaultInput;
     }
 
-    public resetLastInput(): void {
-        this.lastInput = workspace.getConfiguration("spring.initializr").get<string>("defaultGroupId");
+    public resetDefaultInput(): void {
+        this.defaultInput = workspace.getConfiguration("spring.initializr").get<string>("defaultGroupId");
     }
 
     public getNextStep(): IStep | undefined {
@@ -51,7 +51,7 @@ export class SpecifyGroupIdStep implements IStep {
             pickStep: SpecifyGroupIdStep.getInstance(),
             placeholder: "e.g. com.example",
             prompt: "Input Group Id for your project.",
-            defaultValue: SpecifyGroupIdStep.getInstance().lastInput
+            defaultValue: SpecifyGroupIdStep.getInstance().defaultInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/SpecifyGroupIdStep.ts
+++ b/src/handler/SpecifyGroupIdStep.ts
@@ -18,12 +18,20 @@ export class SpecifyGroupIdStep implements IStep {
 
     private lastInput: string;
 
+    constructor() {
+        this.resetLastInput();
+    }
+
     public getLastInput(): string {
         return this.lastInput;
     }
 
     public setLastInput(lastInput: string): void {
         this.lastInput = lastInput;
+    }
+
+    public resetLastInput(): void {
+        this.lastInput = workspace.getConfiguration("spring.initializr").get<string>("defaultGroupId");
     }
 
     public getNextStep(): IStep | undefined {
@@ -38,13 +46,12 @@ export class SpecifyGroupIdStep implements IStep {
     }
 
     private async specifyGroupId(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const defaultGroupId: string = workspace.getConfiguration("spring.initializr").get<string>("defaultGroupId");
         const inputMetaData: IInputMetaData = {
             metadata: projectMetadata,
             pickStep: SpecifyGroupIdStep.getInstance(),
             placeholder: "e.g. com.example",
             prompt: "Input Group Id for your project.",
-            defaultValue: defaultGroupId
+            defaultValue: SpecifyGroupIdStep.getInstance().lastInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -122,11 +122,11 @@ export async function createInputBox(inputMetaData: IInputMetaData): Promise<boo
                 }
                 if (inputMetaData.pickStep instanceof SpecifyGroupIdStep) {
                     inputMetaData.metadata.groupId = inputBox.value;
-                    SpecifyGroupIdStep.getInstance().setLastInput(inputBox.value);
+                    SpecifyGroupIdStep.getInstance().setDefaultInput(inputBox.value);
                     inputMetaData.metadata.pickSteps.push(SpecifyGroupIdStep.getInstance());
                 } else if (inputMetaData.pickStep instanceof SpecifyArtifactIdStep) {
                     inputMetaData.metadata.artifactId = inputBox.value;
-                    SpecifyArtifactIdStep.getInstance().setLastInput(inputBox.value);
+                    SpecifyArtifactIdStep.getInstance().setDefaultInput(inputBox.value);
                     inputMetaData.metadata.pickSteps.push(SpecifyArtifactIdStep.getInstance());
                 }
                 return resolve(true);

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -88,11 +88,7 @@ export async function createInputBox(inputMetaData: IInputMetaData): Promise<boo
         const inputBox: InputBox = window.createInputBox();
         inputBox.placeholder = inputMetaData.placeholder;
         inputBox.prompt = inputMetaData.prompt;
-        if (inputMetaData.pickStep instanceof SpecifyGroupIdStep) {
-            inputBox.value = (SpecifyGroupIdStep.getInstance().getLastInput() === undefined) ? inputMetaData.defaultValue : SpecifyGroupIdStep.getInstance().getLastInput();
-        } else if (inputMetaData.pickStep instanceof SpecifyArtifactIdStep) {
-            inputBox.value = (SpecifyArtifactIdStep.getInstance().getLastInput() === undefined) ? inputMetaData.defaultValue : SpecifyArtifactIdStep.getInstance().getLastInput();
-        }
+        inputBox.value = inputMetaData.defaultValue;
         inputBox.ignoreFocusOut = true;
         if (inputMetaData.metadata.pickSteps.length > 0) {
             inputBox.buttons = [(QuickInputButtons.Back)];


### PR DESCRIPTION
To reset the default value of inputbox to what is defined in the settings, each time when the creating project command is called.
Before this PR: 
when click back button, the input value will be saved as the new default value.
when click `esc`, the input value will also be saved as the new default value.
![before](https://user-images.githubusercontent.com/45906942/90999976-a3264380-e5fa-11ea-8558-0ebb06e74e34.gif)
After this PR:
when click back button, the input value will be saved as the new default value.
when click `esc`, the default value will be reset to the value which is defined in the settings.
![after](https://user-images.githubusercontent.com/45906942/91000023-c18c3f00-e5fa-11ea-9fda-2e80029bbebe.gif)
