### PR TITLE
Commands to start initializr wizard with default selections. Setting for project opening method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ ext install vscode-spring-initializr
 
   // Default value for Packaging. Supported values are "JAR" and "WAR".
   "spring.initializr.defaultPackaging": "JAR",
-  
+
+  // Default value for the method of openining the newly generated project. Supported values are "", "Open" and "Add to Workspace".
+  "spring.initializr.defaultOpenProjectMethod": "Add to Workspace",
 ```
 
 ## Feedback and Questions

--- a/package.json
+++ b/package.json
@@ -130,6 +130,17 @@
           ],
           "scope": "window",
           "description": "Default packaging."
+        },
+        "spring.initializr.defaultOpenProjectMethod": {
+          "default": "",
+          "type": "string",
+          "scope": "window",
+          "description": "Default method of opening newly generated project",
+          "enum": [
+            "",
+            "Open",
+            "Add to Workspace"
+          ]
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,8 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     await loadPackageInfo(context);
 
     context.subscriptions.push(
-        instrumentAndRegisterCommand("spring.initializr.maven-project", async (operationId) => await new GenerateProjectHandler("maven-project").run(operationId), true),
-        instrumentAndRegisterCommand("spring.initializr.gradle-project", async (operationId) => await new GenerateProjectHandler("gradle-project").run(operationId), true),
+        instrumentAndRegisterCommand("spring.initializr.maven-project", async (operationId, defaults) => await new GenerateProjectHandler("maven-project", defaults).run(operationId), true),
+        instrumentAndRegisterCommand("spring.initializr.gradle-project", async (operationId, defaults) => await new GenerateProjectHandler("gradle-project", defaults).run(operationId), true),
     );
 
     context.subscriptions.push(instrumentAndRegisterCommand("spring.initializr.createProject", async () => {

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -62,10 +62,8 @@ export class GenerateProjectHandler extends BaseHandler {
         if (choice === OPEN_IN_NEW_WORKSPACE) {
             vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(path.join(projectLocation, this.metadata.artifactId)), hasOpenFolder);
         } else if (choice === OPEN_IN_CURRENT_WORKSPACE) {
-            if (!vscode.workspace.rootPath || !this.outputUri.fsPath.startsWith(vscode.workspace.rootPath)) {
-                if (!vscode.workspace.workspaceFolders.find((workspaceFolder) => workspaceFolder.uri && this.outputUri.fsPath.startsWith(workspaceFolder.uri.fsPath))) {
-                    vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders.length, null, { uri: vscode.Uri.file(path.join(projectLocation, this.metadata.artifactId)) });
-                }
+            if (!vscode.workspace.workspaceFolders.find((workspaceFolder) => workspaceFolder.uri && this.outputUri.fsPath.startsWith(workspaceFolder.uri.fsPath))) {
+                vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders.length, null, { uri: vscode.Uri.file(path.join(projectLocation, this.metadata.artifactId)) });
             }
         }
     }

--- a/src/handler/IProjectMetadata.ts
+++ b/src/handler/IProjectMetadata.ts
@@ -14,4 +14,15 @@ export interface IProjectMetadata {
     bootVersion?: string;
     dependencies?: IDependenciesItem;
     pickSteps: IStep[];
+    defaults: IDefaultProjectData;
+}
+
+export interface IDefaultProjectData {
+    language?: string;
+    javaVersion?: string;
+    groupId?: string;
+    artifactId?: string;
+    packaging?: string;
+    dependencies?: string[];
+    targetFolder?: string;
 }

--- a/src/handler/SpecifyArtifactIdStep.ts
+++ b/src/handler/SpecifyArtifactIdStep.ts
@@ -51,7 +51,7 @@ export class SpecifyArtifactIdStep implements IStep {
             pickStep: SpecifyArtifactIdStep.getInstance(),
             placeholder: "e.g. demo",
             prompt: "Input Artifact Id for your project.",
-            defaultValue: SpecifyArtifactIdStep.getInstance().defaultInput
+            defaultValue: projectMetadata.defaults.artifactId || SpecifyArtifactIdStep.getInstance().defaultInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/SpecifyDependenciesStep.ts
+++ b/src/handler/SpecifyDependenciesStep.ts
@@ -33,6 +33,7 @@ export class SpecifyDependenciesStep implements IStep {
         let current: IDependenciesItem = null;
         let result: boolean = false;
         const disposables: Disposable[] = [];
+        dependencyManager.selectedIds = projectMetadata.defaults.dependencies || [];
         do {
             const quickPickItems: Array<QuickPickItem & IDependenciesItem> = await dependencyManager.getQuickPickItems(projectMetadata.serviceUrl, projectMetadata.bootVersion, { hasLastSelected: true });
             result = await new Promise<boolean>(async (resolve, reject) => {
@@ -75,7 +76,7 @@ export class SpecifyDependenciesStep implements IStep {
             }
         } while (current && current.itemType === "dependency");
         projectMetadata.dependencies = current;
-        dependencyManager.updateLastUsedDependencies(projectMetadata.dependencies);
+        dependencyManager.updateLastUsedDependencies(current);
         return result;
     }
 }

--- a/src/handler/SpecifyGroupIdStep.ts
+++ b/src/handler/SpecifyGroupIdStep.ts
@@ -51,7 +51,7 @@ export class SpecifyGroupIdStep implements IStep {
             pickStep: SpecifyGroupIdStep.getInstance(),
             placeholder: "e.g. com.example",
             prompt: "Input Group Id for your project.",
-            defaultValue: SpecifyGroupIdStep.getInstance().defaultInput
+            defaultValue: projectMetadata.defaults.groupId || SpecifyGroupIdStep.getInstance().defaultInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/SpecifyJavaVersionStep.ts
+++ b/src/handler/SpecifyJavaVersionStep.ts
@@ -28,7 +28,7 @@ export class SpecifyJavaVersionStep implements IStep {
     }
 
     private async specifyJavaVersion(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const javaVersion: string = workspace.getConfiguration("spring.initializr").get<string>("defaultJavaVersion");
+        const javaVersion: string = projectMetadata.defaults.javaVersion || workspace.getConfiguration("spring.initializr").get<string>("defaultJavaVersion");
         if (javaVersion) {
             projectMetadata.javaVersion = javaVersion;
             return true;

--- a/src/handler/SpecifyLanguageStep.ts
+++ b/src/handler/SpecifyLanguageStep.ts
@@ -28,7 +28,7 @@ export class SpecifyLanguageStep implements IStep {
     }
 
     private async specifyLanguage(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const language: string = workspace.getConfiguration("spring.initializr").get<string>("defaultLanguage");
+        const language: string = projectMetadata.defaults.language || workspace.getConfiguration("spring.initializr").get<string>("defaultLanguage");
         if (language) {
             projectMetadata.language = language && language.toLowerCase();
             return true;

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -28,7 +28,7 @@ export class SpecifyPackagingStep implements IStep {
     }
 
     private async specifyPackaging(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const packaging: string = workspace.getConfiguration("spring.initializr").get<string>("defaultPackaging");
+        const packaging: string = projectMetadata.defaults.packaging || workspace.getConfiguration("spring.initializr").get<string>("defaultPackaging");
         if (packaging) {
             projectMetadata.packaging = packaging && packaging.toLowerCase();
             return true;


### PR DESCRIPTION
This PR implements the following:

1. Project Opening Method Setting. Once a project is generated user is prompted to open the project in a new workspace or add to a current workspace. There are environments where opening a project in new workspace isn't a desired option hence it is best to have a setting for it thus option to open new workspace for generated project is hidden right from startup. User could have just opened a folder (not a workspace) and generated the project under the root folder in this case workspace don't need to be created.

2. Commands that start off the Spring Initializr wizard with some default selections such as language, java version, packaging, dependencies, target folder etc.
