### PR TITLE
0.6.1: fix error cannot read property 'replace' of undefined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "vscode-spring-initializr" extension will be documented in this file.
 
+## 0.6.1
+- Fix Error: Cannot read property 'split' of undefined. [#162](https://github.com/microsoft/vscode-spring-initializr/issues/162#issuecomment-726832226)
+
 ## 0.6.0
 - Allow commands to start initializr wizard with default selections.
 - Add a new setting `spring.initializr.defaultOpenProjectMethod` for default project opening method.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-spring-initializr",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-spring-initializr",
   "displayName": "Spring Initializr Java Support",
   "description": "A lightweight extension based on Spring Initializr to generate quick start Spring Boot Java projects.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "icon": "resources/logo.png",
   "publisher": "vscjava",
   "aiKey": "05fb8871-fbf0-488f-8453-a74cf0ca9b93",

--- a/src/Utils/VersionHelper.ts
+++ b/src/Utils/VersionHelper.ts
@@ -56,13 +56,16 @@ export function compareVersions(a: string, b: string): number {
             return result;
         }
     }
-    const aqual: string = parseQualifier(versionA[3]);
-    const bqual: string = parseQualifier(versionB[3]);
+    // version[3] can be undefined
+    const aqualRaw: string = versionA[3] || "RELEASE";
+    const bqualRaw: string = versionB[3] || "RELEASE";
+    const aqual: string = parseQualifier(aqualRaw);
+    const bqual: string = parseQualifier(bqualRaw);
     result = qualifiers.indexOf(aqual) - qualifiers.indexOf(bqual);
     if (result !== 0) {
         return result;
     }
-    return versionA[3].localeCompare(versionB[3]);
+    return aqualRaw.localeCompare(bqualRaw);
 }
 
 function parseQualifier(version: string): string {


### PR DESCRIPTION
Root cause:
when comparing version `2.4.0`  with `2.4.0.M`, qualifier can be undefined, leading to the issue.

patch for https://github.com/microsoft/vscode-spring-initializr/issues/162#issuecomment-726832226
