### PR TITLE
fix: Get QuickPick options from fetched matadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "mocha": "^7.1.1",
     "ts-loader": "^4.4.2",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3",
+    "typescript": "^4.2.3",
     "vscode-test": "^1.2.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.12"

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -3,6 +3,7 @@
 
 import { QuickPickItem } from "vscode";
 import { IDependenciesItem } from "../DependencyManager";
+import { Identifiable } from "../model/Metadata";
 
 export interface IStep {
     getNextStep(): IStep | undefined;
@@ -32,12 +33,17 @@ export interface IDefaultProjectData {
     targetFolder?: string;
 }
 
-export interface IPickMetadata {
+export interface IHandlerItem<T extends Identifiable> extends QuickPickItem {
+    label: string;
+    value?: T;
+}
+
+export interface IPickMetadata<T extends Identifiable> {
     metadata: IProjectMetadata;
     title: string;
     pickStep: IStep;
     placeholder: string;
-    items: QuickPickItem[];
+    items: Array<IHandlerItem<T>>;
 }
 
 export interface IInputMetaData {

--- a/src/handler/SpecifyBootVersionStep.ts
+++ b/src/handler/SpecifyBootVersionStep.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Disposable, QuickInputButtons, QuickPick, window } from "vscode";
 import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wrapper";
-import { OperationCanceledError } from "../Errors";
-import { IValue, serviceManager } from "../model";
-import { IProjectMetadata, IStep } from "./HandlerInterfaces";
+import { serviceManager } from "../model";
+import { BootVersion, MatadataType } from "../model/Metadata";
+import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyLanguageStep } from "./SpecifyLanguageStep";
+import { createPickBox } from "./utils";
 
 export class SpecifyBootVersionStep implements IStep {
 
@@ -29,46 +29,13 @@ export class SpecifyBootVersionStep implements IStep {
     }
 
     private async specifyBootVersion(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const disposables: Disposable[] = [];
-        const result: boolean = await new Promise<boolean>(async (resolve, reject) => {
-            const pickBox: QuickPick<{ value: IValue, label: string }> = window.createQuickPick<{ value: IValue, label: string }>();
-            pickBox.title = "Spring Initializr: Specify Spring Boot version",
-            pickBox.placeholder = "Specify Spring Boot version.";
-            try {
-                pickBox.items = await serviceManager.getBootVersions(projectMetadata.serviceUrl).then(versions => versions.map(v => ({ value: v, label: v.name })));
-            } catch (error) {
-                return reject(error);
-            }
-            pickBox.ignoreFocusOut = true;
-            if (projectMetadata.pickSteps.length > 0) {
-                pickBox.buttons = [(QuickInputButtons.Back)];
-                disposables.push(
-                    pickBox.onDidTriggerButton((item) => {
-                        if (item === QuickInputButtons.Back) {
-                            return resolve(false);
-                        }
-                    })
-                );
-            }
-            disposables.push(
-                pickBox.onDidAccept(() => {
-                    if (!pickBox.selectedItems[0]) {
-                        return;
-                    }
-                    projectMetadata.bootVersion = pickBox.selectedItems[0] && pickBox.selectedItems[0].value && pickBox.selectedItems[0].value.id;
-                    projectMetadata.pickSteps.push(SpecifyBootVersionStep.getInstance());
-                    return resolve(true);
-                }),
-                pickBox.onDidHide(() => {
-                    return reject(new OperationCanceledError("BootVersion not specified."));
-                })
-            );
-            disposables.push(pickBox);
-            pickBox.show();
-        });
-        for (const d of disposables) {
-            d.dispose();
-        }
-        return result;
+        const pickMetaData: IPickMetadata<BootVersion> = {
+            metadata: projectMetadata,
+            title: "Spring Initializr: Specify Spring Boot version",
+            pickStep: SpecifyBootVersionStep.getInstance(),
+            placeholder: "Specify Spring Boot version.",
+            items: await serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.BOOTVERSION),
+        };
+        return await createPickBox(pickMetaData);
     }
 }

--- a/src/handler/SpecifyJavaVersionStep.ts
+++ b/src/handler/SpecifyJavaVersionStep.ts
@@ -3,6 +3,8 @@
 
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import { serviceManager } from "../model";
+import { JavaVersion, MatadataType } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyDependenciesStep } from "./SpecifyDependenciesStep";
 import { createPickBox } from "./utils";
@@ -32,12 +34,12 @@ export class SpecifyJavaVersionStep implements IStep {
             projectMetadata.javaVersion = javaVersion;
             return true;
         }
-        const pickMetaData: IPickMetadata = {
+        const pickMetaData: IPickMetadata<JavaVersion> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify Java version",
             pickStep: SpecifyJavaVersionStep.getInstance(),
             placeholder: "Specify Java version.",
-            items: [{ label: "11" }, { label: "1.8" }, { label: "14" }]
+            items: await serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.JAVAVERSION),
         };
         return await createPickBox(pickMetaData);
     }

--- a/src/handler/SpecifyLanguageStep.ts
+++ b/src/handler/SpecifyLanguageStep.ts
@@ -3,6 +3,8 @@
 
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import { serviceManager } from "../model";
+import { Language, MatadataType } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyGroupIdStep } from "./SpecifyGroupIdStep";
 import { createPickBox } from "./utils";
@@ -32,12 +34,12 @@ export class SpecifyLanguageStep implements IStep {
             projectMetadata.language = language && language.toLowerCase();
             return true;
         }
-        const pickMetaData: IPickMetadata = {
+        const pickMetaData: IPickMetadata<Language> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify project language",
             pickStep: SpecifyLanguageStep.getInstance(),
             placeholder: "Specify project language.",
-            items: [{ label: "Java" }, { label: "Kotlin" }, { label: "Groovy" }]
+            items: await serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.LANGUAGE),
         };
         return await createPickBox(pickMetaData);
     }

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -3,6 +3,8 @@
 
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import { serviceManager } from "../model";
+import { MatadataType, Packaging } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyJavaVersionStep } from "./SpecifyJavaVersionStep";
 import { createPickBox } from "./utils";
@@ -32,12 +34,12 @@ export class SpecifyPackagingStep implements IStep {
             projectMetadata.packaging = packaging && packaging.toLowerCase();
             return true;
         }
-        const pickMetaData: IPickMetadata = {
+        const pickMetaData: IPickMetadata<Packaging> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify packaging type",
             pickStep: SpecifyPackagingStep.getInstance(),
             placeholder: "Specify packaging type.",
-            items: [{ label: "JAR" }, { label: "WAR" }]
+            items: await serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.PACKAGING),
         };
         return await createPickBox(pickMetaData);
     }

--- a/src/model/Metadata.ts
+++ b/src/model/Metadata.ts
@@ -13,11 +13,18 @@ export interface Metadata {
     type: Category<ProjectType>;
 }
 
+export enum MatadataType {
+    BOOTVERSION,
+    JAVAVERSION,
+    LANGUAGE,
+    PACKAGING,
+}
+
 interface Nameable {
     name: string;
 }
 
-interface Identifiable extends Nameable {
+export interface Identifiable extends Nameable {
     id: string;
 }
 
@@ -30,10 +37,10 @@ interface ProjectType extends Identifiable {
     action: string;
 }
 
-type BootVersion = Identifiable;
-type Packaging = Identifiable;
-type JavaVersion = Identifiable;
-type Language = Identifiable;
+export type BootVersion = Identifiable;
+export type Packaging = Identifiable;
+export type JavaVersion = Identifiable;
+export type Language = Identifiable;
 
 export interface DependencyGroup extends Category<Dependency>, Nameable {
 }


### PR DESCRIPTION
In spring initializr steps, will get QuickPick options from fetched matadata, instead of hard coding the options. see #170.