### PR TITLE
fix: Java version is inconsistent between user settings and command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,9 @@
           "type": "string",
           "enum": [
             "",
-            "1.8",
             "11",
-            "14"
+            "15",
+            "8"
           ],
           "scope": "window",
           "description": "Default Java version."


### PR DESCRIPTION
fix #175 
We have to hard code it in package.json since VS Code doesn't support changing setting Enum values with API yet.