### PR TITLE
partially support virtual workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,9 +84,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.30.0.tgz",
-      "integrity": "sha512-xRas+PW/fM/MoonB+Pawg48bGTjCqJsFUFwZpH/q2oW80AMHGDAUTUqySBnqeQ18e/SNi7NOCf3ZkYOzKm3Pqw==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.37.0.tgz",
+      "integrity": "sha512-PRfeuqYuzk3vjf+puzxltIUWC+AhEGYpFX29/37w30DQSQnpf5AgMVf7GDBAdmTbWTBou+EMFz/Ne6XCM/KxzQ==",
       "dev": true
     },
     "@types/xml-zero-lexer": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "url": "https://github.com/Microsoft/vscode-spring-initializr.git"
   },
   "engines": {
-    "vscode": "^1.30.0"
+    "vscode": "^1.37.0"
+  },
+  "capabilities": {
+    "virtualWorkspaces": true
   },
   "categories": [
     "Other"
@@ -52,6 +55,14 @@
         {
           "command": "spring.initializr.createProject",
           "when": "never"
+        },
+        {
+          "command": "spring.initializr.maven-project",
+          "when": "!virtualWorkspace"
+        },
+        {
+          "command": "spring.initializr.gradle-project",
+          "when": "!virtualWorkspace"
         }
       ],
       "editor/context": [
@@ -159,7 +170,7 @@
     "@types/md5": "^2.1.33",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.13",
-    "@types/vscode": "1.30.0",
+    "@types/vscode": "1.37.0",
     "@types/xml-zero-lexer": "^2.1.0",
     "@types/xml2js": "^0.4.4",
     "glob": "^7.1.4",

--- a/src/Utils/VSCodeUI.ts
+++ b/src/Utils/VSCodeUI.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as fs from "fs-extra";
 import * as os from "os";
 import {
     InputBoxOptions,
@@ -90,12 +89,6 @@ export async function openDialogForFile(customOptions?: OpenDialogOptions): Prom
         return Promise.resolve(result[0]);
     } else {
         return Promise.resolve(undefined);
-    }
-}
-
-export async function openFileIfExists(filepath: string): Promise<void> {
-    if (await fs.pathExists(filepath)) {
-        window.showTextDocument(Uri.file(filepath), { preview: false });
     }
 }
 

--- a/src/Utils/fsHelper.ts
+++ b/src/Utils/fsHelper.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 import { FileType, Uri, workspace } from "vscode";
 
 export async function isDirectory(uri: Uri): Promise<boolean | undefined> {

--- a/src/Utils/fsHelper.ts
+++ b/src/Utils/fsHelper.ts
@@ -1,0 +1,18 @@
+import { FileType, Uri, workspace } from "vscode";
+
+export async function isDirectory(uri: Uri): Promise<boolean | undefined> {
+  try {
+    return (await workspace.fs.stat(uri)).type === FileType.Directory;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export async function pathExists(uri: Uri): Promise<boolean> {
+  try {
+    await workspace.fs.stat(uri);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -136,9 +136,9 @@ export function buildXmlContent(obj: any, options?: {}): string {
 
 export async function getTargetPomXml(): Promise<vscode.Uri> {
     if (vscode.window.activeTextEditor) {
-        const fsPath: string = vscode.window.activeTextEditor.document.fileName;
-        if ("pom.xml" === path.basename(fsPath).toLowerCase()) {
-            return vscode.Uri.file(fsPath);
+        const activeUri = vscode.window.activeTextEditor.document.uri;
+        if ("pom.xml" === path.basename(activeUri.path).toLowerCase()) {
+            return activeUri;
         }
     }
 


### PR DESCRIPTION
See #185 

Virtual workspace is e.g. when you open GitHub repo directly in VS Code where scheme of URI is `vscode-vfs` instead of `file`. 

In this PR:
- Declare virual workspaces capability in package.json
- Hide "create project" from command palatte.
- Refactor "add starters" to support virtual workspaces.

PS:
Must use `vscode.workspace.fs` (since v1.37.0) instead of native NodeJS `fs`.
 