### PR TITLE
Fix version detection when relativePath is not specified

### DIFF
--- a/src/handler/AddStartersHandler.ts
+++ b/src/handler/AddStartersHandler.ts
@@ -123,6 +123,8 @@ async function searchForBootVersion(uri: vscode.Uri): Promise<string> {
     // search recursively in parent pom
     const relativePath = getParentRelativePath(projectNode);
     if (relativePath) {
+        // <relativePath> not empty, search filesystem first.
+        // See https://maven.apache.org/ref/3.8.5/maven-model/maven.html#parent
         const newPath = path.join(path.dirname(uri.path), relativePath);
         let newUri = uri.with({path: newPath});
 
@@ -133,5 +135,8 @@ async function searchForBootVersion(uri: vscode.Uri): Promise<string> {
             return await searchForBootVersion(newUri);
         }
     }
+
+    // TODO: continue to search repositories (local, remote)
+
     return undefined;
 }

--- a/src/model/pomxml/PomXml.ts
+++ b/src/model/pomxml/PomXml.ts
@@ -8,6 +8,10 @@ function isNullOrEmptyNode(node: any): boolean {
     return _.isEmpty(node) || _.isEqual(node, [""]);
 }
 
+function isNullNode(node: any) {
+    return _.isEmpty(node);
+}
+
 function ensureNode(parentNode: XmlNode, nodeName: string, defaultValue: any): any {
     if (isNullOrEmptyNode(parentNode[nodeName])) {
         parentNode[nodeName] = [defaultValue];
@@ -15,11 +19,11 @@ function ensureNode(parentNode: XmlNode, nodeName: string, defaultValue: any): a
     return parentNode[nodeName][0];
 }
 
-function getNode(parentNode: any, nodeName: string, fallbackValue?: any): any {
-    if (isNullOrEmptyNode(parentNode[nodeName])) {
-        return fallbackValue;
+function getNode(parentNode: any, nodeName: string, fallbackValue?: any, allowEmpty?: boolean): any {
+    if (allowEmpty) {
+        return isNullNode(parentNode[nodeName]) ? fallbackValue : parentNode[nodeName][0];
     } else {
-        return parentNode[nodeName][0];
+        return isNullOrEmptyNode(parentNode[nodeName]) ? fallbackValue : parentNode[nodeName][0];
     }
 }
 
@@ -85,7 +89,12 @@ export function getBootVersion(projectNode: XmlNode): string {
     return bootVersion;
 }
 
+/**
+ * Get value of <relativePath> under <parent> node.
+ * @param projectNode xml object of <project> node.
+ * @returns value of <relativePath> node. Defaults to "../pom.xml" if unspecified.
+ */
 export function getParentRelativePath(projectNode: XmlNode): string {
     const parentNode: XmlNode = getNode(projectNode, "parent", {});
-    return getNode(parentNode, "relativePath");
+    return getNode(parentNode, "relativePath", "../pom.xml", true);
 }


### PR DESCRIPTION
See #201 

`relativePath` defaults to "../pom.xml". And when it's explicitly set to empty, we should skip searching on filesystem for parent projects.

Reference:
https://maven.apache.org/ref/3.8.5/maven-model/maven.html#parent