### PR TITLE
add separator between starter groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
-      "integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
+      "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
       "dev": true
     },
     "@types/xml2js": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/Microsoft/vscode-spring-initializr.git"
   },
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.64.0"
   },
   "capabilities": {
     "virtualWorkspaces": true
@@ -186,7 +186,7 @@
     "@types/md5": "^2.3.2",
     "@types/mocha": "^9.1.1",
     "@types/node": "^10.17.60",
-    "@types/vscode": "1.63.0",
+    "@types/vscode": "1.64.0",
     "@types/xml2js": "^0.4.11",
     "@vscode/test-electron": "^2.1.5",
     "glob": "^7.2.3",


### PR DESCRIPTION
`QuickPickItemKind` was introduced since VS Code v1.64. 