### PR TITLE
Issue 217: Allow Package Name specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,12 @@
           "scope": "window",
           "description": "Default value for Artifact Id."
         },
+        "spring.initializr.defaultPackageName": {
+          "default": "com.example.demo",
+          "type": "string",
+          "scope": "window",
+          "description": "Default value for Package Name. If Group Id and Artifact Id are customized, this setting will be ignored in favor of the combination of such values."
+        },
         "spring.initializr.defaultPackaging": {
           "default": "",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -128,12 +128,6 @@
           "scope": "window",
           "description": "Default value for Artifact Id."
         },
-        "spring.initializr.defaultPackageName": {
-          "default": "com.example.demo",
-          "type": "string",
-          "scope": "window",
-          "description": "Default value for Package Name. If Group Id and Artifact Id are customized, this setting will be ignored in favor of the combination of such values."
-        },
         "spring.initializr.defaultPackaging": {
           "default": "",
           "type": "string",

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -114,6 +114,10 @@ export function artifactIdValidation(value: string): string | undefined {
     return (/^[a-z_][a-z0-9_]*(-[a-z_][a-z0-9_]*)*$/.test(value)) ? undefined : "Invalid Artifact Id";
 }
 
+export function packageNameValidation(value: string): string {
+    return (/^[a-z_][a-z0-9_]*(\.[a-z0-9_]+)*$/.test(value)) ? null : "Invalid Package Name";
+}
+
 export async function readXmlContent(xml: string, options?: {}): Promise<any> {
     const opts: {} = Object.assign({ explicitArray: true }, options);
     return new Promise<{}>(

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -15,6 +15,7 @@ import { BaseHandler } from "./BaseHandler";
 import { IDefaultProjectData, IProjectMetadata, IStep, ParentFolder } from "./HandlerInterfaces";
 import { SpecifyArtifactIdStep } from "./SpecifyArtifactIdStep";
 import { SpecifyGroupIdStep } from "./SpecifyGroupIdStep";
+import { SpecifyPackageNameStep } from "./SpecifyPackageNameStep";
 import { SpecifyServiceUrlStep } from "./SpecifyServiceUrlStep";
 
 const OPEN_IN_NEW_WORKSPACE = "Open";
@@ -46,6 +47,7 @@ export class GenerateProjectHandler extends BaseHandler {
 
         SpecifyArtifactIdStep.getInstance().resetDefaultInput();
         SpecifyGroupIdStep.getInstance().resetDefaultInput();
+        SpecifyPackageNameStep.getInstance().resetDefaultInput();
         while (step !== undefined) {
             step = await step.execute(operationId, this.metadata);
         }
@@ -87,6 +89,7 @@ export class GenerateProjectHandler extends BaseHandler {
             `javaVersion=${this.metadata.javaVersion}`,
             `groupId=${this.metadata.groupId}`,
             `artifactId=${this.metadata.artifactId}`,
+            `packageName=${this.metadata.packageName}`,
             `name=${this.metadata.artifactId}`,
             `packaging=${this.metadata.packaging}`,
             `bootVersion=${this.metadata.bootVersion}`,

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -16,6 +16,7 @@ export interface IProjectMetadata {
     javaVersion?: string;
     groupId?: string;
     artifactId?: string;
+    packageName?: string;
     packaging?: string;
     bootVersion?: string;
     dependencies?: IDependenciesItem;
@@ -29,6 +30,7 @@ export interface IDefaultProjectData {
     javaVersion?: string;
     groupId?: string;
     artifactId?: string;
+    packageName?: string;
     packaging?: string;
     dependencies?: string[];
     targetFolder?: string;

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -30,7 +30,6 @@ export interface IDefaultProjectData {
     javaVersion?: string;
     groupId?: string;
     artifactId?: string;
-    packageName?: string;
     packaging?: string;
     dependencies?: string[];
     targetFolder?: string;

--- a/src/handler/SpecifyArtifactIdStep.ts
+++ b/src/handler/SpecifyArtifactIdStep.ts
@@ -4,7 +4,7 @@
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
 import { IInputMetaData, IProjectMetadata, IStep } from "./HandlerInterfaces";
-import { SpecifyPackagingStep } from "./SpecifyPackagingStep";
+import { SpecifyPackageNameStep } from "./SpecifyPackageNameStep";
 import { createInputBox } from "./utils";
 
 export class SpecifyArtifactIdStep implements IStep {
@@ -34,7 +34,7 @@ export class SpecifyArtifactIdStep implements IStep {
     }
 
     public getNextStep(): IStep | undefined {
-        return SpecifyPackagingStep.getInstance();
+        return SpecifyPackageNameStep.getInstance();
     }
 
     public async execute(operationId: string, projectMetadata: IProjectMetadata): Promise<IStep | undefined> {

--- a/src/handler/SpecifyPackageNameStep.ts
+++ b/src/handler/SpecifyPackageNameStep.ts
@@ -44,7 +44,7 @@ export class SpecifyPackageNameStep implements IStep {
     }
 
     private async specifyPackageName(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const recommendedPackageName = `${projectMetadata.groupId}.${projectMetadata.artifactId}`
+        const recommendedPackageName = `${projectMetadata.groupId}.${projectMetadata.artifactId}`.replace("-", "_");
         
         const inputMetaData: IInputMetaData = {
             metadata: projectMetadata,

--- a/src/handler/SpecifyPackageNameStep.ts
+++ b/src/handler/SpecifyPackageNameStep.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { workspace } from "vscode";
+import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import { IInputMetaData, IProjectMetadata, IStep } from "./HandlerInterfaces";
+import { SpecifyPackagingStep } from "./SpecifyPackagingStep";
+import { createInputBox } from "./utils";
+
+export class SpecifyPackageNameStep implements IStep {
+
+    public static getInstance(): SpecifyPackageNameStep {
+        return SpecifyPackageNameStep.specifyPackageNameStep;
+    }
+
+    private static specifyPackageNameStep: SpecifyPackageNameStep = new SpecifyPackageNameStep();
+
+    private defaultInput: string;
+
+    constructor() {
+        this.resetDefaultInput();
+    }
+
+    public getDefaultInput(): string {
+        return this.defaultInput;
+    }
+
+    public setDefaultInput(defaultInput: string): void {
+        this.defaultInput = defaultInput;
+    }
+
+    public resetDefaultInput(): void {
+        this.defaultInput = workspace.getConfiguration("spring.initializr").get<string>("defaultPackageName");
+    }
+
+    public getNextStep(): IStep | undefined {
+        return SpecifyPackagingStep.getInstance();
+    }
+
+    public async execute(operationId: string, projectMetadata: IProjectMetadata): Promise<IStep | undefined> {
+        if (!await instrumentOperationStep(operationId, "PackageName", this.specifyPackageName)(projectMetadata)) {
+            return projectMetadata.pickSteps.pop();
+        }
+        return this.getNextStep();
+    }
+
+    private async specifyPackageName(projectMetadata: IProjectMetadata): Promise<boolean> {
+        const recommendedPackageName = `${projectMetadata.groupId}.${projectMetadata.artifactId}`;
+        projectMetadata.defaults.packageName = recommendedPackageName;
+
+        const inputMetaData: IInputMetaData = {
+            metadata: projectMetadata,
+            title: "Spring Initializr: Input Package Name",
+            pickStep: SpecifyPackageNameStep.getInstance(),
+            placeholder: "e.g. com.example",
+            prompt: "Input Package Name for your project.",
+            defaultValue: projectMetadata.defaults.packageName || SpecifyPackageNameStep.getInstance().defaultInput
+        };
+        return await createInputBox(inputMetaData);
+    }
+}

--- a/src/handler/SpecifyPackageNameStep.ts
+++ b/src/handler/SpecifyPackageNameStep.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
 import { IInputMetaData, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyPackagingStep } from "./SpecifyPackagingStep";
@@ -30,7 +29,7 @@ export class SpecifyPackageNameStep implements IStep {
     }
 
     public resetDefaultInput(): void {
-        this.defaultInput = workspace.getConfiguration("spring.initializr").get<string>("defaultPackageName");
+        this.defaultInput = null;
     }
 
     public getNextStep(): IStep | undefined {
@@ -45,16 +44,15 @@ export class SpecifyPackageNameStep implements IStep {
     }
 
     private async specifyPackageName(projectMetadata: IProjectMetadata): Promise<boolean> {
-        const recommendedPackageName = `${projectMetadata.groupId}.${projectMetadata.artifactId}`;
-        projectMetadata.defaults.packageName = recommendedPackageName;
-
+        const recommendedPackageName = `${projectMetadata.groupId}.${projectMetadata.artifactId}`
+        
         const inputMetaData: IInputMetaData = {
             metadata: projectMetadata,
             title: "Spring Initializr: Input Package Name",
             pickStep: SpecifyPackageNameStep.getInstance(),
             placeholder: "e.g. com.example",
             prompt: "Input Package Name for your project.",
-            defaultValue: projectMetadata.defaults.packageName || SpecifyPackageNameStep.getInstance().defaultInput
+            defaultValue: recommendedPackageName || SpecifyPackageNameStep.getInstance().defaultInput
         };
         return await createInputBox(inputMetaData);
     }

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import { Disposable, InputBox, QuickInputButtons, QuickPick, window } from "vscode";
 import { OperationCanceledError } from "../Errors";
 import { Identifiable } from "../model/Metadata";
-import { artifactIdValidation, groupIdValidation } from "../Utils";
+import { artifactIdValidation, groupIdValidation, packageNameValidation } from "../Utils";
 import { IHandlerItem, IInputMetaData, IPickMetadata, IProjectMetadata } from "./HandlerInterfaces";
 import { SpecifyArtifactIdStep } from "./SpecifyArtifactIdStep";
 import { SpecifyBootVersionStep } from "./SpecifyBootVersionStep";
@@ -14,6 +14,7 @@ import { SpecifyJavaVersionStep } from "./SpecifyJavaVersionStep";
 import { SpecifyLanguageStep } from "./SpecifyLanguageStep";
 import { SpecifyPackagingStep } from "./SpecifyPackagingStep";
 import { SpecifyServiceUrlStep } from "./SpecifyServiceUrlStep";
+import { SpecifyPackageNameStep } from "./SpecifyPackageNameStep";
 
 const DEFAULT_SERVICE_URL: string = "https://start.spring.io";
 
@@ -133,6 +134,8 @@ export async function createInputBox(inputMetaData: IInputMetaData): Promise<boo
                     validCheck = groupIdValidation(inputBox.value);
                 } else if (inputMetaData.pickStep instanceof SpecifyArtifactIdStep) {
                     validCheck = artifactIdValidation(inputBox.value);
+                } else if (inputMetaData.pickStep instanceof SpecifyPackageNameStep) {
+                    validCheck = packageNameValidation(inputBox.value);
                 }
                 inputBox.validationMessage = validCheck;
             }),
@@ -148,6 +151,10 @@ export async function createInputBox(inputMetaData: IInputMetaData): Promise<boo
                     inputMetaData.metadata.artifactId = inputBox.value;
                     SpecifyArtifactIdStep.getInstance().setDefaultInput(inputBox.value);
                     inputMetaData.metadata.pickSteps.push(SpecifyArtifactIdStep.getInstance());
+                } else if (inputMetaData.pickStep instanceof SpecifyPackageNameStep) {
+                    inputMetaData.metadata.packageName = inputBox.value;
+                    SpecifyPackageNameStep.getInstance().setDefaultInput(inputBox.value);
+                    inputMetaData.metadata.pickSteps.push(SpecifyPackageNameStep.getInstance());
                 }
                 return resolve(true);
             }),
@@ -156,6 +163,8 @@ export async function createInputBox(inputMetaData: IInputMetaData): Promise<boo
                     return reject(new OperationCanceledError("GroupId not specified."));
                 } else if (inputMetaData.pickStep instanceof SpecifyArtifactIdStep) {
                     return reject(new OperationCanceledError("ArtifactId not specified."));
+                } else if (inputMetaData.pickStep instanceof SpecifyPackageNameStep) {
+                    return reject(new OperationCanceledError("PackageName not specified."));
                 }
                 return reject(new Error("Unknown inputting step"));
             })


### PR DESCRIPTION
New step for allowing specification of a custom Package Name during project generation.

There is no default setting provided since the recommended value is always based on the combination of Group Id and Artifact Id.


Closes #217 