### PR TITLE
Issue 215: Use API defaults for a simpler experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
           ],
           "scope": "window",
           "description": "Controls if a new sub-folder should be created for the newly generated project."
+        },
+        "spring.initializr.enableSmartDefaults": {
+          "default": false,
+          "type": "boolean",
+          "scope": "window",
+          "description": "Use default values provided by Spring Initializr API for Spring Boot version, language, Java version and packaging."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -164,11 +164,11 @@
           "scope": "window",
           "description": "Controls if a new sub-folder should be created for the newly generated project."
         },
-        "spring.initializr.enableSmartDefaults": {
+        "spring.initializr.useApiDefaults": {
           "default": false,
           "type": "boolean",
           "scope": "window",
-          "description": "Use default values provided by Spring Initializr API for Spring Boot version, language, Java version and packaging."
+          "description": "Use default values provided by Spring Initializr API for Spring Boot version, language, Java version and packaging. When specific defaults are set for each configuration, those take precedence over the API defaults."
         }
       }
     }

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -36,7 +36,7 @@ export class GenerateProjectHandler extends BaseHandler {
             pickSteps: [],
             defaults: defaults || {},
             parentFolder: settings.get<ParentFolder>("parentFolder"),
-            enableSmartDefaults: settings.get("enableSmartDefaults")
+            useApiDefaults: settings.get("useApiDefaults")
         };
     }
 

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -29,10 +29,14 @@ export class GenerateProjectHandler extends BaseHandler {
     constructor(projectType: "maven-project" | "gradle-project", defaults?: IDefaultProjectData) {
         super();
         this.projectType = projectType;
+
+        const settings = vscode.workspace.getConfiguration("spring.initializr");
+
         this.metadata = {
             pickSteps: [],
             defaults: defaults || {},
-            parentFolder: vscode.workspace.getConfiguration("spring.initializr").get<ParentFolder>("parentFolder")
+            parentFolder: settings.get<ParentFolder>("parentFolder"),
+            enableSmartDefaults: settings.get("enableSmartDefaults")
         };
     }
 

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -22,6 +22,7 @@ export interface IProjectMetadata {
     pickSteps: IStep[];
     defaults: IDefaultProjectData;
     parentFolder?: ParentFolder;
+    enableSmartDefaults?: boolean;
 }
 
 export interface IDefaultProjectData {
@@ -37,6 +38,7 @@ export interface IDefaultProjectData {
 export interface IHandlerItem<T extends Identifiable> extends QuickPickItem {
     label: string;
     value?: T;
+    default?: boolean;
 }
 
 export interface IPickMetadata<T extends Identifiable> {

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -22,7 +22,7 @@ export interface IProjectMetadata {
     pickSteps: IStep[];
     defaults: IDefaultProjectData;
     parentFolder?: ParentFolder;
-    enableSmartDefaults?: boolean;
+    useApiDefaults?: boolean;
 }
 
 export interface IDefaultProjectData {

--- a/src/handler/SpecifyBootVersionStep.ts
+++ b/src/handler/SpecifyBootVersionStep.ts
@@ -3,7 +3,7 @@
 
 import { instrumentOperationStep, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { serviceManager } from "../model";
-import { BootVersion, MatadataType } from "../model/Metadata";
+import { BootVersion, MetadataType } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyLanguageStep } from "./SpecifyLanguageStep";
 import { createPickBox } from "./utils";
@@ -29,13 +29,21 @@ export class SpecifyBootVersionStep implements IStep {
     }
 
     private async specifyBootVersion(projectMetadata: IProjectMetadata): Promise<boolean> {
+        const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.BOOTVERSION);
+
+        if (projectMetadata.enableSmartDefaults === true) {
+            projectMetadata.bootVersion = items.find(x => x.default === true)?.value?.id;
+            return true;
+        }
+
         const pickMetaData: IPickMetadata<BootVersion> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify Spring Boot version",
             pickStep: SpecifyBootVersionStep.getInstance(),
             placeholder: "Specify Spring Boot version.",
-            items: serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.BOOTVERSION),
+            items: items,
         };
+
         return await createPickBox(pickMetaData);
     }
 }

--- a/src/handler/SpecifyBootVersionStep.ts
+++ b/src/handler/SpecifyBootVersionStep.ts
@@ -32,8 +32,12 @@ export class SpecifyBootVersionStep implements IStep {
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.BOOTVERSION);
 
         if (projectMetadata.enableSmartDefaults === true) {
-            projectMetadata.bootVersion = items.find(x => x.default === true)?.value?.id;
-            return true;
+            const recommendedBootVersion: string = items.find(x => x.default === true)?.value?.id;
+
+            if (recommendedBootVersion) {
+                projectMetadata.bootVersion = recommendedBootVersion;
+                return true;
+            }
         }
 
         const pickMetaData: IPickMetadata<BootVersion> = {

--- a/src/handler/SpecifyBootVersionStep.ts
+++ b/src/handler/SpecifyBootVersionStep.ts
@@ -31,7 +31,7 @@ export class SpecifyBootVersionStep implements IStep {
     private async specifyBootVersion(projectMetadata: IProjectMetadata): Promise<boolean> {
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.BOOTVERSION);
 
-        if (projectMetadata.enableSmartDefaults === true) {
+        if (projectMetadata.useApiDefaults === true) {
             const recommendedBootVersion: string = items.find(x => x.default === true)?.value?.id;
 
             if (recommendedBootVersion) {

--- a/src/handler/SpecifyJavaVersionStep.ts
+++ b/src/handler/SpecifyJavaVersionStep.ts
@@ -38,7 +38,7 @@ export class SpecifyJavaVersionStep implements IStep {
         
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.JAVAVERSION);
 
-        if (projectMetadata.enableSmartDefaults === true) {
+        if (projectMetadata.useApiDefaults === true) {
             const recommendedJavaVersion: string = items.find(x => x.default === true)?.value?.id;
 
             if (recommendedJavaVersion) {

--- a/src/handler/SpecifyJavaVersionStep.ts
+++ b/src/handler/SpecifyJavaVersionStep.ts
@@ -39,8 +39,12 @@ export class SpecifyJavaVersionStep implements IStep {
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.JAVAVERSION);
 
         if (projectMetadata.enableSmartDefaults === true) {
-            projectMetadata.javaVersion = items.find(x => x.default === true)?.value?.id;
-            return true;
+            const recommendedJavaVersion: string = items.find(x => x.default === true)?.value?.id;
+
+            if (recommendedJavaVersion) {
+                projectMetadata.javaVersion = recommendedJavaVersion;
+                return true;
+            }
         }
         
         const pickMetaData: IPickMetadata<JavaVersion> = {

--- a/src/handler/SpecifyJavaVersionStep.ts
+++ b/src/handler/SpecifyJavaVersionStep.ts
@@ -4,7 +4,7 @@
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
 import { serviceManager } from "../model";
-import { JavaVersion, MatadataType } from "../model/Metadata";
+import { JavaVersion, MetadataType } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyDependenciesStep } from "./SpecifyDependenciesStep";
 import { createPickBox } from "./utils";
@@ -30,17 +30,27 @@ export class SpecifyJavaVersionStep implements IStep {
 
     private async specifyJavaVersion(projectMetadata: IProjectMetadata): Promise<boolean> {
         const javaVersion: string = projectMetadata.defaults.javaVersion || workspace.getConfiguration("spring.initializr").get<string>("defaultJavaVersion");
+
         if (javaVersion) {
             projectMetadata.javaVersion = javaVersion;
             return true;
         }
+        
+        const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.JAVAVERSION);
+
+        if (projectMetadata.enableSmartDefaults === true) {
+            projectMetadata.javaVersion = items.find(x => x.default === true)?.value?.id;
+            return true;
+        }
+        
         const pickMetaData: IPickMetadata<JavaVersion> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify Java version",
             pickStep: SpecifyJavaVersionStep.getInstance(),
             placeholder: "Specify Java version.",
-            items: serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.JAVAVERSION),
+            items: items
         };
+        
         return await createPickBox(pickMetaData);
     }
 }

--- a/src/handler/SpecifyLanguageStep.ts
+++ b/src/handler/SpecifyLanguageStep.ts
@@ -39,8 +39,12 @@ export class SpecifyLanguageStep implements IStep {
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.LANGUAGE);
 
         if (projectMetadata.enableSmartDefaults === true) {
-            projectMetadata.language = items.find(x => x.default === true)?.label.toLowerCase();
-            return true;
+            const recommendedLanguage: string = items.find(x => x.default === true)?.label.toLowerCase();
+
+            if (recommendedLanguage) {
+                projectMetadata.language = recommendedLanguage;
+                return true;
+            }
         }
 
         const pickMetaData: IPickMetadata<Language> = {

--- a/src/handler/SpecifyLanguageStep.ts
+++ b/src/handler/SpecifyLanguageStep.ts
@@ -38,7 +38,7 @@ export class SpecifyLanguageStep implements IStep {
 
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.LANGUAGE);
 
-        if (projectMetadata.enableSmartDefaults === true) {
+        if (projectMetadata.useApiDefaults === true) {
             const recommendedLanguage: string = items.find(x => x.default === true)?.label.toLowerCase();
 
             if (recommendedLanguage) {

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -39,8 +39,12 @@ export class SpecifyPackagingStep implements IStep {
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.PACKAGING);
 
         if (projectMetadata.enableSmartDefaults === true) {
-            projectMetadata.packaging = items.find(x => x.default === true)?.label?.toLowerCase();
-            return true;
+            const recommendedPackaging: string = items.find(x => x.default === true)?.label?.toLowerCase();
+            
+            if (recommendedPackaging) {
+                projectMetadata.packaging = recommendedPackaging;
+                return true;
+            }
         }
         
         const pickMetaData: IPickMetadata<Packaging> = {

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -38,7 +38,7 @@ export class SpecifyPackagingStep implements IStep {
 
         const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.PACKAGING);
 
-        if (projectMetadata.enableSmartDefaults === true) {
+        if (projectMetadata.useApiDefaults === true) {
             const recommendedPackaging: string = items.find(x => x.default === true)?.label?.toLowerCase();
             
             if (recommendedPackaging) {

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -4,7 +4,7 @@
 import { workspace } from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
 import { serviceManager } from "../model";
-import { MatadataType, Packaging } from "../model/Metadata";
+import { MetadataType, Packaging } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
 import { SpecifyJavaVersionStep } from "./SpecifyJavaVersionStep";
 import { createPickBox } from "./utils";
@@ -30,17 +30,27 @@ export class SpecifyPackagingStep implements IStep {
 
     private async specifyPackaging(projectMetadata: IProjectMetadata): Promise<boolean> {
         const packaging: string = projectMetadata.defaults.packaging || workspace.getConfiguration("spring.initializr").get<string>("defaultPackaging");
+        
         if (packaging) {
             projectMetadata.packaging = packaging && packaging.toLowerCase();
             return true;
         }
+
+        const items = await serviceManager.getItems(projectMetadata.serviceUrl, MetadataType.PACKAGING);
+
+        if (projectMetadata.enableSmartDefaults === true) {
+            projectMetadata.packaging = items.find(x => x.default === true)?.label?.toLowerCase();
+            return true;
+        }
+        
         const pickMetaData: IPickMetadata<Packaging> = {
             metadata: projectMetadata,
             title: "Spring Initializr: Specify packaging type",
             pickStep: SpecifyPackagingStep.getInstance(),
             placeholder: "Specify packaging type.",
-            items: serviceManager.getItems(projectMetadata.serviceUrl, MatadataType.PACKAGING),
+            items: items
         };
+        
         return await createPickBox(pickMetaData);
     }
 }

--- a/src/model/Metadata.ts
+++ b/src/model/Metadata.ts
@@ -13,7 +13,7 @@ export interface Metadata {
     type: Category<ProjectType>;
 }
 
-export enum MatadataType {
+export enum MetadataType {
     BOOTVERSION,
     JAVAVERSION,
     LANGUAGE,


### PR DESCRIPTION
New setting to allow for Spring Initializr recommended defaults to be used for following configurations:

- Spring Boot version
- Language
- Packaging
- Java version

---

**Setting:** `spring.initializr.useApiDefaults`\*
**Type:** boolean
**Default value:** `false`

---

The default values will be based on the _default_ field from API's response, such as below:
```json
"javaVersion": {
    "type": "single-select",
    "default": "17",
    "values": [
        {
            "id": "21",
            "name": "21"
        },
        {
            "id": "17",
            "name": "17"
        }
    ]
}
```

If there's a default value set via existing configurations such as `defaultJavaVersion`, then those take precedence over the API recommendation.

If the API response does not contain a default value for a property, then the existing behavior applies and the extension prompts the user to select one.

Closes #215 