### PR TITLE
Issue 236: New command for generating Gradle projects with Kotlin DSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
         "category": "Spring Initializr"
       },
       {
+        "command": "spring.initializr.gradle-project-kotlin",
+        "title": "Create a Gradle Project with Kotlin DSL...",
+        "category": "Spring Initializr"
+      },
+      {
         "command": "spring.initializr.addStarters",
         "title": "Add Starters...",
         "category": "Spring Initializr"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import {
 } from "vscode-extension-telemetry-wrapper";
 import { AddStartersHandler, GenerateProjectHandler } from "./handler";
 import { getTargetPomXml, loadPackageInfo } from "./Utils";
+import { ProjectType } from "./model";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     await initializeFromJsonFile(context.asAbsolutePath("./package.json"), { firstParty: true });
@@ -26,14 +27,16 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     await loadPackageInfo(context);
 
     context.subscriptions.push(
-        instrumentAndRegisterCommand("spring.initializr.maven-project", async (operationId, defaults) => await new GenerateProjectHandler("maven-project", defaults).run(operationId), true),
-        instrumentAndRegisterCommand("spring.initializr.gradle-project", async (operationId, defaults) => await new GenerateProjectHandler("gradle-project", defaults).run(operationId), true),
+        instrumentAndRegisterCommand("spring.initializr.maven-project", async (operationId, defaults) => await new GenerateProjectHandler(ProjectType.MAVEN, defaults).run(operationId), true),
+        instrumentAndRegisterCommand("spring.initializr.gradle-project", async (operationId, defaults) => await new GenerateProjectHandler(ProjectType.GRADLE, defaults).run(operationId), true),
+        instrumentAndRegisterCommand("spring.initializr.gradle-project-kotlin", async (operationId, defaults) => await new GenerateProjectHandler(ProjectType.GRADLE_KOTLIN, defaults).run(operationId), true)
     );
 
     context.subscriptions.push(instrumentAndRegisterCommand("spring.initializr.createProject", async () => {
         const projectType: { value: string, label: string } = await vscode.window.showQuickPick([
             { value: "maven-project", label: "Maven Project" },
-            { value: "gradle-project", label: "Gradle Project" }
+            { value: "gradle-project", label: "Gradle Project" },
+            { value: "gradle-project-kotlin", label: "Gradle Project - Kotlin DSL" }
         ], { placeHolder: "Select project type." });
         if (projectType) {
             await vscode.commands.executeCommand(`spring.initializr.${projectType.value}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,8 +11,8 @@ import {
     instrumentOperation
 } from "vscode-extension-telemetry-wrapper";
 import { AddStartersHandler, GenerateProjectHandler } from "./handler";
-import { getTargetPomXml, loadPackageInfo } from "./Utils";
 import { ProjectType } from "./model";
+import { getTargetPomXml, loadPackageInfo } from "./Utils";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     await initializeFromJsonFile(context.asAbsolutePath("./package.json"));

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -16,17 +16,18 @@ import { IDefaultProjectData, IProjectMetadata, IStep, ParentFolder } from "./Ha
 import { SpecifyArtifactIdStep } from "./SpecifyArtifactIdStep";
 import { SpecifyGroupIdStep } from "./SpecifyGroupIdStep";
 import { SpecifyServiceUrlStep } from "./SpecifyServiceUrlStep";
+import { ProjectType } from "../model";
 
 const OPEN_IN_NEW_WORKSPACE = "Open";
 const OPEN_IN_CURRENT_WORKSPACE = "Add to Workspace";
 
 export class GenerateProjectHandler extends BaseHandler {
 
-    private projectType: "maven-project" | "gradle-project";
+    private projectType: ProjectType;
     private outputUri: vscode.Uri;
     private metadata: IProjectMetadata;
 
-    constructor(projectType: "maven-project" | "gradle-project", defaults?: IDefaultProjectData) {
+    constructor(projectType: ProjectType, defaults?: IDefaultProjectData) {
         super();
         this.projectType = projectType;
         this.metadata = {

--- a/src/model/Interfaces.ts
+++ b/src/model/Interfaces.ts
@@ -109,3 +109,9 @@ export enum BooleanString {
     TRUE = "true",
     FALSE = "false",
 }
+
+export enum ProjectType {
+    MAVEN = "maven-project",
+    GRADLE = "gradle-project",
+    GRADLE_KOTLIN = "gradle-project-kotlin"
+}


### PR DESCRIPTION
New command `spring.initializr.gradle-project-kotlin` for generating Gradle projects with Kotlin DSL.

Closes #236 