### PR TITLE
Update default Java versions in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
           "type": "string",
           "enum": [
             "",
-            "11",
-            "15",
-            "8"
+            "17",
+            "21",
+            "24"
           ],
           "scope": "window",
           "description": "Default Java version."


### PR DESCRIPTION
Changed the default Java versions from 8-11-15 to 17-21-24. This aligns the extension with the currently availableJava releases, ensuring developers can start with supported versions by default.
<img width="463" height="225" alt="image" src="https://github.com/user-attachments/assets/af723592-04d8-4170-a168-15df759983e2" />

<img width="517" height="345" alt="image" src="https://github.com/user-attachments/assets/13fff94e-7d98-4364-a413-bd16a3b7ead3" />


