### PR TITLE
Add configuration file format selection (properties/yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3019,7 +3019,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tslint": {
       "version": "5.20.1",
@@ -4123,8 +4124,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
       "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -4139,8 +4139,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -4164,8 +4163,7 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "7.1.1",
@@ -4209,8 +4207,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -5856,7 +5853,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tslint": {
       "version": "5.20.1",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,16 @@
           "scope": "window",
           "description": "Default packaging."
         },
+        "spring.initializr.defaultConfigurationFileFormat": {
+          "default": "properties",
+          "type": "string",
+          "enum": [
+            "properties",
+            "yaml"
+          ],
+          "scope": "window",
+          "description": "Default Spring Boot configuration file format."
+        },
         "spring.initializr.defaultOpenProjectMethod": {
           "default": "",
           "type": "string",

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -12,7 +12,7 @@ import { downloadFile } from "../Utils";
 import { pathExists } from "../Utils/fsHelper";
 import { openDialogForFolder } from "../Utils/VSCodeUI";
 import { BaseHandler } from "./BaseHandler";
-import { IDefaultProjectData, IProjectMetadata, IStep, ParentFolder } from "./HandlerInterfaces";
+import { ConfigurationFileFormat, IDefaultProjectData, IProjectMetadata, IStep, ParentFolder } from "./HandlerInterfaces";
 import { SpecifyArtifactIdStep } from "./SpecifyArtifactIdStep";
 import { SpecifyGroupIdStep } from "./SpecifyGroupIdStep";
 import { SpecifyPackageNameStep } from "./SpecifyPackageNameStep";
@@ -34,6 +34,7 @@ export class GenerateProjectHandler extends BaseHandler {
         this.metadata = {
             pickSteps: [],
             defaults: defaults || {},
+            configurationFileFormat: ConfigurationFileFormat.YAML,
             parentFolder: vscode.workspace.getConfiguration("spring.initializr").get<ParentFolder>("parentFolder")
         };
     }
@@ -95,6 +96,7 @@ export class GenerateProjectHandler extends BaseHandler {
             `packaging=${this.metadata.packaging}`,
             `bootVersion=${this.metadata.bootVersion}`,
             `dependencies=${this.metadata.dependencies.id}`,
+            `configurationFileFormat=${this.metadata.configurationFileFormat}`,
         ];
 
         const targetUrl = new URL(this.metadata.serviceUrl);

--- a/src/handler/HandlerInterfaces.ts
+++ b/src/handler/HandlerInterfaces.ts
@@ -19,6 +19,7 @@ export interface IProjectMetadata {
     packageName?: string;
     packaging?: string;
     bootVersion?: string;
+    configurationFileFormat?: ConfigurationFileFormat;
     dependencies?: IDependenciesItem;
     pickSteps: IStep[];
     defaults: IDefaultProjectData;
@@ -31,6 +32,7 @@ export interface IDefaultProjectData {
     groupId?: string;
     artifactId?: string;
     packaging?: string;
+    configurationFileFormat?: ConfigurationFileFormat;
     dependencies?: string[];
     targetFolder?: string;
 }
@@ -60,4 +62,9 @@ export interface IInputMetaData {
 export enum ParentFolder {
     ARTIFACT_ID = "artifactId",
     NONE = "none"
+}
+
+export enum ConfigurationFileFormat {
+    PROPERTIES = "properties",
+    YAML = "yaml"
 }

--- a/src/handler/SpecifyConfigurationFileFormatStep.ts
+++ b/src/handler/SpecifyConfigurationFileFormatStep.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { window, workspace } from "vscode";
+import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import { ConfigurationFileFormat, IProjectMetadata, IStep } from "./HandlerInterfaces";
+import { SpecifyJavaVersionStep } from "./SpecifyJavaVersionStep";
+
+export class SpecifyConfigurationFileFormatStep implements IStep {
+
+    public static getInstance(): SpecifyConfigurationFileFormatStep {
+        return SpecifyConfigurationFileFormatStep.instance;
+    }
+
+    private static instance: SpecifyConfigurationFileFormatStep = new SpecifyConfigurationFileFormatStep();
+
+    public getNextStep(): IStep | undefined {
+        return SpecifyJavaVersionStep.getInstance();
+    }
+
+    public async execute(operationId: string, projectMetadata: IProjectMetadata): Promise<IStep | undefined> {
+        if (!await instrumentOperationStep(operationId, "ConfigurationFileFormat", this.specifyConfigurationFileFormat)(projectMetadata)) {
+            return projectMetadata.pickSteps.pop();
+        }
+        return this.getNextStep();
+    }
+
+    private async specifyConfigurationFileFormat(projectMetadata: IProjectMetadata): Promise<boolean> {
+
+        const defaultFormat: ConfigurationFileFormat =
+            projectMetadata.defaults.configurationFileFormat
+            ?? workspace.getConfiguration("spring.initializr")
+                .get<ConfigurationFileFormat>("defaultConfigurationFileFormat")
+            ?? ConfigurationFileFormat.PROPERTIES;
+
+
+        const selection = await window.showQuickPick([
+            {
+                label: "Properties",
+                detail: "application.properties",
+                value: ConfigurationFileFormat.PROPERTIES
+            },
+            {
+                label: "YAML",
+                detail: "application.yaml",
+                value: ConfigurationFileFormat.YAML
+            }
+        ], {
+            title: "Spring Initializr: Specify configuration file format",
+            placeHolder: "Choose configuration file format"
+        });
+
+        if (!selection) {
+            return false;
+        }
+
+        projectMetadata.configurationFileFormat = selection.value || defaultFormat;
+
+        return true;
+    }
+}

--- a/src/handler/SpecifyPackagingStep.ts
+++ b/src/handler/SpecifyPackagingStep.ts
@@ -6,8 +6,8 @@ import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
 import { serviceManager } from "../model";
 import { MatadataType, Packaging } from "../model/Metadata";
 import { IPickMetadata, IProjectMetadata, IStep } from "./HandlerInterfaces";
-import { SpecifyJavaVersionStep } from "./SpecifyJavaVersionStep";
 import { createPickBox } from "./utils";
+import { SpecifyConfigurationFileFormatStep } from "./SpecifyConfigurationFileFormatStep";
 
 export class SpecifyPackagingStep implements IStep {
 
@@ -18,7 +18,7 @@ export class SpecifyPackagingStep implements IStep {
     private static specifyPackagingStep: SpecifyPackagingStep = new SpecifyPackagingStep();
 
     public getNextStep(): IStep | undefined {
-        return SpecifyJavaVersionStep.getInstance();
+        return SpecifyConfigurationFileFormatStep.getInstance();
     }
 
     public async execute(operationId: string, projectMetadata: IProjectMetadata): Promise<IStep | undefined> {


### PR DESCRIPTION
Adds a wizard step allowing users to choose the Spring Boot configuration file format (**application.properties** or **application.yaml**).

### Details

Spring Initializr supports selecting configuration file format via the configurationFileFormat parameter. This change:

- Introduces a new wizard step after packaging selection
- Allows choosing between Properties and YAML formats
- Defaults to Properties to preserve existing behaviour
- Adds configurable default via spring.initializr.defaultConfigurationFileFormat

Fixes #267 