### PR TITLE
Add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   darwin:
     name: macOS

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -11,6 +11,9 @@ on:
     # Schedule for five minutes after the hour, every hour
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+
 jobs:
   noResponse:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     name: Windows


### PR DESCRIPTION
Add `permissions` blocks to all GitHub Actions workflows to follow the principle of least privilege for the `GITHUB_TOKEN`, fixing 4 CodeQL `actions/missing-workflow-permissions` alerts:

- `linux.yml`, `macOS.yml`, `windows.yml`: `contents: read`
- `no-response.yml`: `issues: write`