### PR TITLE
fix: prevent Gradle project extraction hangs

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -6,40 +6,13 @@ open source projects along with the license information below. We acknowledge an
 are grateful to these developers for their contribution to open source.
 
 
-1. adm-zip (https://github.com/cthackers/adm-zip)
-2. fs-extra (https://github.com/jprichardson/node-fs-extra)
-3. htmlparser2 (https://github.com/fb55/htmlparser2)
-4. lodash (lodash/lodash)
-5. md5 (https://github.com/pvorb/node-md5)
-6. vscode-extension-telemetry-wrapper (https://github.com/Eskibear/vscode-extension-telemetry-wrapper)
-7. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
-
-adm-zip NOTICES BEGIN HERE
-=============================
-MIT License
-
-Copyright (c) 2012 Another-D-Mention Software and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-=========================================
-END OF adm-zip NOTICES AND INFORMATION
+1. fs-extra (https://github.com/jprichardson/node-fs-extra)
+2. htmlparser2 (https://github.com/fb55/htmlparser2)
+3. lodash (lodash/lodash)
+4. md5 (https://github.com/pvorb/node-md5)
+5. vscode-extension-telemetry-wrapper (https://github.com/Eskibear/vscode-extension-telemetry-wrapper)
+6. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
+7. yauzl (https://github.com/thejoshwolfe/yauzl)
 
 fs-extra NOTICES BEGIN HERE
 =============================
@@ -207,3 +180,30 @@ IN THE SOFTWARE.
 
 =========================================
 END OF xml2js NOTICES AND INFORMATION
+
+yauzl NOTICES BEGIN HERE
+=============================
+The MIT License (MIT)
+
+Copyright (c) 2014 Josh Wolfe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+=========================================
+END OF yauzl NOTICES AND INFORMATION

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -6,7 +6,7 @@ open source projects along with the license information below. We acknowledge an
 are grateful to these developers for their contribution to open source.
 
 
-1. extract-zip (https://github.com/maxogden/extract-zip)
+1. adm-zip (https://github.com/cthackers/adm-zip)
 2. fs-extra (https://github.com/jprichardson/node-fs-extra)
 3. htmlparser2 (https://github.com/fb55/htmlparser2)
 4. lodash (lodash/lodash)
@@ -14,34 +14,32 @@ are grateful to these developers for their contribution to open source.
 6. vscode-extension-telemetry-wrapper (https://github.com/Eskibear/vscode-extension-telemetry-wrapper)
 7. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
 
-extract-zip NOTICES BEGIN HERE
+adm-zip NOTICES BEGIN HERE
 =============================
-Copyright (c) 2014 Max Ogden and other contributors
-All rights reserved.
+MIT License
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Copyright (c) 2012 Another-D-Mention Software and other contributors
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 =========================================
-END OF extract-zip NOTICES AND INFORMATION
+END OF adm-zip NOTICES AND INFORMATION
 
 fs-extra NOTICES BEGIN HERE
 =============================

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,15 @@
       "name": "vscode-spring-initializr",
       "version": "0.12.0",
       "dependencies": {
-        "adm-zip": "^0.5.17",
         "fs-extra": "^5.0.0",
         "htmlparser2": "^9.1.0",
         "lodash": "^4.18.1",
         "md5": "^2.3.0",
         "vscode-extension-telemetry-wrapper": "^0.15.2",
-        "xml2js": "^0.5.0"
+        "xml2js": "^0.5.0",
+        "yauzl": "^3.4.0"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.6",
         "@types/fs-extra": "^5.1.0",
         "@types/glob": "^7.2.0",
         "@types/lodash": "^4.17.7",
@@ -26,6 +25,7 @@
         "@types/node": "^16.18.104",
         "@types/vscode": "1.75.0",
         "@types/xml2js": "^0.4.14",
+        "@types/yauzl": "^3.4.0",
         "@vscode/test-electron": "^2.4.1",
         "glob": "^7.2.3",
         "mocha": "^11.7.5",
@@ -411,16 +411,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.6.tgz",
-      "integrity": "sha512-lRlcSLg5Yoo7C2H2AUiAoYlvifWoCx/se7iUNiCBTfEVVYFVn+Tr9ZGed4K73tYgLe9O4PjdJvbxlkdAOx/qiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -513,6 +503,16 @@
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
       "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha1-k94X2xWJRy0wtOEGxedxG88ypek=",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -763,15 +763,6 @@
       },
       "peerDependencies": {
         "acorn": "^8.14.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -2542,6 +2533,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3755,6 +3752,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha1-iLKiFFXzfKfczy7rM7rLQ5IyJxk=",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4060,15 +4069,6 @@
       "dev": true,
       "optional": true
     },
-    "@types/adm-zip": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.6.tgz",
-      "integrity": "sha512-lRlcSLg5Yoo7C2H2AUiAoYlvifWoCx/se7iUNiCBTfEVVYFVn+Tr9ZGed4K73tYgLe9O4PjdJvbxlkdAOx/qiw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4160,6 +4160,15 @@
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
       "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha1-k94X2xWJRy0wtOEGxedxG88ypek=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4381,11 +4390,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "requires": {}
-    },
-    "adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="
     },
     "agent-base": {
       "version": "7.1.1",
@@ -5628,6 +5632,11 @@
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6485,6 +6494,14 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha1-iLKiFFXzfKfczy7rM7rLQ5IyJxk=",
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vscode-spring-initializr",
       "version": "0.12.0",
       "dependencies": {
-        "extract-zip": "^1.7.0",
+        "adm-zip": "^0.5.17",
         "fs-extra": "^5.0.0",
         "htmlparser2": "^9.1.0",
         "lodash": "^4.18.1",
@@ -17,6 +17,7 @@
         "xml2js": "^0.5.0"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.6",
         "@types/fs-extra": "^5.1.0",
         "@types/glob": "^7.2.0",
         "@types/lodash": "^4.17.7",
@@ -410,6 +411,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.6.tgz",
+      "integrity": "sha512-lRlcSLg5Yoo7C2H2AUiAoYlvifWoCx/se7iUNiCBTfEVVYFVn+Tr9ZGed4K73tYgLe9O4PjdJvbxlkdAOx/qiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -754,6 +765,15 @@
         "acorn": "^8.14.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -1015,18 +1035,11 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/builtin-modules": {
       "version": "1.1.1",
@@ -1261,24 +1274,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1300,14 +1300,6 @@
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/decamelize": {
@@ -1528,20 +1520,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-      "dependencies": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1571,14 +1549,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fill-range": {
@@ -1891,7 +1861,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/interpret": {
       "version": "2.2.0",
@@ -1997,7 +1968,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2241,6 +2213,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2258,6 +2231,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -2368,11 +2342,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -2573,11 +2542,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2663,12 +2627,14 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2779,7 +2745,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/sax": {
       "version": "1.4.1",
@@ -2925,6 +2892,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3318,11 +3286,6 @@
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -3377,7 +3340,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
       "version": "0.15.2",
@@ -3791,15 +3755,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4104,6 +4059,15 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@types/adm-zip": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.6.tgz",
+      "integrity": "sha512-lRlcSLg5Yoo7C2H2AUiAoYlvifWoCx/se7iUNiCBTfEVVYFVn+Tr9ZGed4K73tYgLe9O4PjdJvbxlkdAOx/qiw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/eslint": {
       "version": "9.6.1",
@@ -4418,6 +4382,11 @@
       "dev": true,
       "requires": {}
     },
+    "adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="
+    },
     "agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -4585,15 +4554,11 @@
         "ieee754": "^1.2.1"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -4758,21 +4723,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -4789,14 +4744,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
     },
     "decamelize": {
       "version": "4.0.0",
@@ -4945,17 +4892,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true
     },
-    "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-      "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
-        "yauzl": "^2.10.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4973,14 +4909,6 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "requires": {
-        "pend": "~1.2.0"
-      }
     },
     "fill-range": {
       "version": "7.1.1",
@@ -5199,7 +5127,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "interpret": {
       "version": "2.2.0",
@@ -5269,7 +5198,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -5461,7 +5391,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "minipass": {
       "version": "7.1.3",
@@ -5473,6 +5404,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -5554,11 +5486,6 @@
           "dev": true
         }
       }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -5701,11 +5628,6 @@
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
-    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5769,12 +5691,14 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5851,7 +5775,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "sax": {
       "version": "1.4.1",
@@ -5961,6 +5886,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -6233,11 +6159,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -6262,7 +6183,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "vscode-extension-telemetry-wrapper": {
       "version": "0.15.2",
@@ -6563,15 +6485,6 @@
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
         "is-plain-obj": "^2.1.0"
-      }
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "update-tpn": "node scripts/update-third-party-notice.js"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.6",
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.2.0",
     "@types/lodash": "^4.17.7",
@@ -190,6 +189,7 @@
     "@types/node": "^16.18.104",
     "@types/vscode": "1.75.0",
     "@types/xml2js": "^0.4.14",
+    "@types/yauzl": "^3.4.0",
     "@vscode/test-electron": "^2.4.1",
     "glob": "^7.2.3",
     "mocha": "^11.7.5",
@@ -200,13 +200,13 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "adm-zip": "^0.5.17",
     "fs-extra": "^5.0.0",
     "htmlparser2": "^9.1.0",
     "lodash": "^4.18.1",
     "md5": "^2.3.0",
     "vscode-extension-telemetry-wrapper": "^0.15.2",
-    "xml2js": "^0.5.0"
+    "xml2js": "^0.5.0",
+    "yauzl": "^3.4.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.5"

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "update-tpn": "node scripts/update-third-party-notice.js"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.6",
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.2.0",
     "@types/lodash": "^4.17.7",
@@ -199,7 +200,7 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "extract-zip": "^1.7.0",
+    "adm-zip": "^0.5.17",
     "fs-extra": "^5.0.0",
     "htmlparser2": "^9.1.0",
     "lodash": "^4.18.1",

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as extract from "extract-zip";
+import AdmZip = require("adm-zip");
 import * as fse from "fs-extra";
 import * as path from "path";
 import { URL } from "url";
@@ -21,6 +21,7 @@ import { ProjectType } from "../model";
 
 const OPEN_IN_NEW_WORKSPACE = "Open";
 const OPEN_IN_CURRENT_WORKSPACE = "Add to Workspace";
+const UNZIP_TIMEOUT_IN_MS = 2 * 60 * 1000;
 
 export class GenerateProjectHandler extends BaseHandler {
 
@@ -138,25 +139,53 @@ async function specifyTargetFolder(metadata: IProjectMetadata): Promise<vscode.U
 }
 
 async function downloadAndUnzip(targetUrl: string, targetFolder: vscode.Uri): Promise<void> {
-    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, (p: vscode.Progress<{ message?: string }>) => new Promise<void>(
-        async (resolve: () => void, reject: (e: Error) => void): Promise<void> => {
-            let filepath: string;
-            try {
-                p.report({ message: "Downloading zip package..." });
-                filepath = await downloadFile(targetUrl);
-            } catch (error) {
-                return reject(error);
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (p: vscode.Progress<{ message?: string }>) => {
+        p.report({ message: "Downloading zip package..." });
+        const filepath = await downloadFile(targetUrl);
+
+        p.report({ message: "Starting to unzip..." });
+        await unzipWithTimeout(filepath, targetFolder.fsPath);
+    });
+}
+
+async function unzipWithTimeout(filepath: string, targetFolder: string): Promise<void> {
+    const zip = new AdmZip(filepath);
+    const unzipPromise = new Promise<void>((resolve: () => void, reject: (error: Error) => void): void => {
+        zip.extractAllToAsync(targetFolder, true, false, (error?: Error): void => error ? reject(error) : resolve());
+    });
+    await withTimeout(unzipPromise, UNZIP_TIMEOUT_IN_MS, "Timed out while unzipping the generated project.");
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, timeoutMessage: string): Promise<T> {
+    return new Promise<T>((resolve: (value: T) => void, reject: (e: Error) => void): void => {
+        let completed: boolean = false;
+        const timeout = setTimeout((): void => {
+            if (completed) {
+                return;
             }
 
-            p.report({ message: "Starting to unzip..." });
-            extract(filepath, { dir: targetFolder.fsPath }, (err) => {
-                if (err) {
-                    return reject(err);
-                }
-                return resolve();
-            });
-        },
-    ));
+            completed = true;
+            reject(new Error(timeoutMessage));
+        }, timeoutInMs);
+
+        promise.then((value: T): void => {
+            if (completed) {
+                return;
+            }
+
+            completed = true;
+            clearTimeout(timeout);
+            resolve(value);
+        }, (error: Error): void => {
+            if (completed) {
+                return;
+            }
+
+            completed = true;
+            clearTimeout(timeout);
+            reject(error);
+        });
+    });
 }
 
 async function specifyOpenMethod(hasOpenFolder: boolean, projectLocation: vscode.Uri): Promise<string> {

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -151,13 +151,25 @@ async function downloadAndUnzip(targetUrl: string, targetFolder: vscode.Uri): Pr
 }
 
 async function unzipWithTimeout(filepath: string, targetFolder: string): Promise<void> {
-    await withTimeout(extractZip(filepath, targetFolder), UNZIP_TIMEOUT_IN_MS, "Timed out while unzipping the generated project.");
+    const controller = new AbortController();
+    await withTimeout(
+        extractZip(filepath, targetFolder, controller.signal),
+        UNZIP_TIMEOUT_IN_MS,
+        "Timed out while unzipping the generated project.",
+        () => controller.abort(),
+    );
 }
 
-async function extractZip(filepath: string, targetFolder: string): Promise<void> {
+async function extractZip(filepath: string, targetFolder: string, signal: AbortSignal): Promise<void> {
     const zip = await yauzl.openPromise(filepath, { strictFileNames: true, validateEntrySizes: true });
     const targetRoot = path.resolve(targetFolder);
+    const closeZip = (): void => zip.close();
+    signal.addEventListener("abort", closeZip, { once: true });
     try {
+        if (signal.aborted) {
+            throw new Error("Zip extraction aborted.");
+        }
+
         for await (const entry of zip.eachEntry()) {
             const targetPath = path.resolve(targetRoot, entry.fileName);
             if (targetPath !== targetRoot && !targetPath.startsWith(`${targetRoot}${path.sep}`)) {
@@ -171,18 +183,19 @@ async function extractZip(filepath: string, targetFolder: string): Promise<void>
 
             await fse.ensureDir(path.dirname(targetPath));
             const readStream = await zip.openReadStreamPromise(entry);
-            await pipeline(readStream, createWriteStream(targetPath));
+            await pipeline(readStream, createWriteStream(targetPath), { signal });
             const mode = (entry.externalFileAttributes >>> 16) & 0xffff;
             if (mode !== 0) {
                 await fse.chmod(targetPath, mode);
             }
         }
     } finally {
+        signal.removeEventListener("abort", closeZip);
         zip.close();
     }
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, timeoutMessage: string): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, timeoutMessage: string, onTimeout: () => void): Promise<T> {
     return new Promise<T>((resolve: (value: T) => void, reject: (e: Error) => void): void => {
         let completed: boolean = false;
         const timeout = setTimeout((): void => {
@@ -191,6 +204,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, timeoutMessage
             }
 
             completed = true;
+            onTimeout();
             reject(new Error(timeoutMessage));
         }, timeoutInMs);
 

--- a/src/handler/GenerateProjectHandler.ts
+++ b/src/handler/GenerateProjectHandler.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import AdmZip = require("adm-zip");
+import { createWriteStream } from "fs";
 import * as fse from "fs-extra";
 import * as path from "path";
+import { pipeline } from "stream/promises";
 import { URL } from "url";
 import * as vscode from "vscode";
 import { instrumentOperationStep } from "vscode-extension-telemetry-wrapper";
+import * as yauzl from "yauzl";
 import { OperationCanceledError } from "../Errors";
 import { downloadFile } from "../Utils";
 import { pathExists } from "../Utils/fsHelper";
@@ -149,11 +151,35 @@ async function downloadAndUnzip(targetUrl: string, targetFolder: vscode.Uri): Pr
 }
 
 async function unzipWithTimeout(filepath: string, targetFolder: string): Promise<void> {
-    const zip = new AdmZip(filepath);
-    const unzipPromise = new Promise<void>((resolve: () => void, reject: (error: Error) => void): void => {
-        zip.extractAllToAsync(targetFolder, true, false, (error?: Error): void => error ? reject(error) : resolve());
-    });
-    await withTimeout(unzipPromise, UNZIP_TIMEOUT_IN_MS, "Timed out while unzipping the generated project.");
+    await withTimeout(extractZip(filepath, targetFolder), UNZIP_TIMEOUT_IN_MS, "Timed out while unzipping the generated project.");
+}
+
+async function extractZip(filepath: string, targetFolder: string): Promise<void> {
+    const zip = await yauzl.openPromise(filepath, { strictFileNames: true, validateEntrySizes: true });
+    const targetRoot = path.resolve(targetFolder);
+    try {
+        for await (const entry of zip.eachEntry()) {
+            const targetPath = path.resolve(targetRoot, entry.fileName);
+            if (targetPath !== targetRoot && !targetPath.startsWith(`${targetRoot}${path.sep}`)) {
+                throw new Error(`Invalid zip entry path: ${entry.fileName}`);
+            }
+
+            if (entry.fileName.endsWith("/")) {
+                await fse.ensureDir(targetPath);
+                continue;
+            }
+
+            await fse.ensureDir(path.dirname(targetPath));
+            const readStream = await zip.openReadStreamPromise(entry);
+            await pipeline(readStream, createWriteStream(targetPath));
+            const mode = (entry.externalFileAttributes >>> 16) & 0xffff;
+            if (mode !== 0) {
+                await fse.chmod(targetPath, mode);
+            }
+        }
+    } finally {
+        zip.close();
+    }
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, timeoutMessage: string): Promise<T> {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
         const extensionTestsPath: string = path.resolve(__dirname, "./suite/index");
 
         // Download VS Code, unzip it and run the integration test
-        const launchArgs: string[] = process.platform === "darwin" ? ["--user-data-dir=/tmp/vscode-spring-initializr-test"] : undefined;
+        const launchArgs: string[] | undefined = process.platform === "darwin" ? ["--user-data-dir=/tmp/vscode-spring-initializr-test"] : undefined;
         await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs });
     } catch (err) {
         console.error("Failed to run tests");

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,7 +16,8 @@ async function main(): Promise<void> {
         const extensionTestsPath: string = path.resolve(__dirname, "./suite/index");
 
         // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        const launchArgs: string[] = process.platform === "darwin" ? ["--user-data-dir=/tmp/vscode-spring-initializr-test"] : undefined;
+        await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs });
     } catch (err) {
         console.error("Failed to run tests");
         process.exit(1);


### PR DESCRIPTION
## Summary

- replace unmaintained `extract-zip` and its vulnerable `yauzl@2`/`fd-slicer` chain with current `yauzl@3.4.0`
- stream entries sequentially with built-in filename and entry-size validation, plus an explicit target-root containment check
- add a two-minute extraction timeout that actively aborts streams and closes the ZIP before reporting an error
- preserve ZIP file permissions and update third-party notices
- use a short macOS test profile path so VS Code's IPC socket stays within the platform limit

The hang occurs on VS Code 1.128.0 because its bundled Node.js 24.17.0 includes the core stream regression described in #282. That regression conflicts with the legacy destroyed-stream handling in the old dependency chain and can leave extraction permanently paused under backpressure.

## Validation

- `npm run compile`
- `npm run tslint`
- `npx tsc -p .`
- `npm audit --omit=dev` reports zero production vulnerabilities
- verified aborting a stalled pipeline destroys both streams and invokes ZIP cleanup
- packaged and installed the VSIX into an isolated VS Code 1.128.0 instance running Node.js 24.17.0
- generated a Gradle project end to end using a validated ZIP fixture with a 131,072-byte incompressible `gradle-wrapper.jar`; extraction completed and the output matched the fixture byte for byte
- verified a ZIP entry containing `../escaped.txt` is rejected without writing outside the target folder
- verified `@vscode/test-electron` honors the short macOS `--user-data-dir` override

Fixes #282