### PR TITLE
chore: upgrade TSLint to 6.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "glob": "^7.2.3",
         "mocha": "^11.8.0",
         "ts-loader": "^9.6.2",
-        "tslint": "^5.20.1",
+        "tslint": "^6.1.3",
         "typescript": "^4.8.4",
         "webpack": "^5.105.4",
         "webpack-cli": "^4.10.0"
@@ -3066,10 +3066,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
+      "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -3079,10 +3081,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "bin": {
@@ -3092,7 +3094,7 @@
         "node": ">=4.8.0"
       },
       "peerDependencies": {
-        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
       }
     },
     "node_modules/tslint/node_modules/ansi-styles": {
@@ -5908,9 +5910,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+      "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -5921,10 +5923,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.13.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "glob": "^7.2.3",
     "mocha": "^11.8.0",
     "ts-loader": "^9.6.2",
-    "tslint": "^5.20.1",
+    "tslint": "^6.1.3",
     "typescript": "^4.8.4",
     "webpack": "^5.105.4",
     "webpack-cli": "^4.10.0"

--- a/src/DependencyManager.ts
+++ b/src/DependencyManager.ts
@@ -31,11 +31,11 @@ export class DependencyManager {
         this.lastselected = idList;
     }
 
-    public async getQuickPickItems(serviceUrl: string, options?: { hasLastSelected: boolean }): Promise<Array<QuickPickItem & IDependenciesItem>> {
+    public async getQuickPickItems(serviceUrl: string, options?: { hasLastSelected: boolean }): Promise<(QuickPickItem & IDependenciesItem)[]> {
         if (this.dependencies.length === 0) {
             await this.initialize(await serviceManager.getAvailableDependencies(serviceUrl, this.bootVersion));
         }
-        const ret: Array<QuickPickItem & IDependenciesItem> = [];
+        const ret: (QuickPickItem & IDependenciesItem)[] = [];
         if (this.selectedIds.length === 0) {
             if (options && options.hasLastSelected && this.lastselected) {
                 const item = this.genLastSelectedItem(this.lastselected);
@@ -133,8 +133,8 @@ function newSeparator(name: string) {
         id: name
     };
 }
-function getLinkButtons(links?: ILinks): Array<QuickInputButton & ILink> {
-    const buttons: Array<QuickInputButton & ILink> = [];
+function getLinkButtons(links?: ILinks): (QuickInputButton & ILink)[] {
+    const buttons: (QuickInputButton & ILink)[] = [];
     if (links?.home?.href) {
         const homeButton = {
             iconPath: new ThemeIcon("home"),


### PR DESCRIPTION
Upgrades TSLint from 5.20.1 to 6.1.3 and updates the four array declarations surfaced by TSLint 6's recommended rules.

Supersedes [#304](https://github.com/microsoft/vscode-spring-initializr/pull/304).

Validation:
- `npm run tslint`
- `npm run compile`
- `npx @vscode/vsce package`
- `npm test` (2 passing)