### PR TITLE
chore: Upgrade TypeScript to 5.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/lodash": "^4.17.25",
         "@types/md5": "^2.3.5",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.18.104",
+        "@types/node": "^16.18.126",
         "@types/vscode": "1.75.0",
         "@types/xml2js": "^0.4.14",
         "@types/yauzl": "^3.4.0",
@@ -30,7 +30,7 @@
         "mocha": "^11.8.0",
         "ts-loader": "^9.6.2",
         "tslint": "^6.1.3",
-        "typescript": "^4.8.4",
+        "typescript": "^5.9.3",
         "webpack": "^5.105.4",
         "webpack-cli": "^4.10.0"
       },
@@ -483,10 +483,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.104",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.104.tgz",
-      "integrity": "sha512-OF3keVCbfPlkzxnnDBUZJn1RiCJzKeadjiW0xTEb0G1SUJ5gDVb3qnzZr2T4uIFvsbKJbXy1v2DN7e2zaEY7jQ==",
-      "dev": true
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.75.0",
@@ -3294,16 +3295,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {
@@ -4150,9 +4152,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.104",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.104.tgz",
-      "integrity": "sha512-OF3keVCbfPlkzxnnDBUZJn1RiCJzKeadjiW0xTEb0G1SUJ5gDVb3qnzZr2T4uIFvsbKJbXy1v2DN7e2zaEY7jQ==",
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "dev": true
     },
     "@types/vscode": {
@@ -6140,9 +6142,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/lodash": "^4.17.25",
         "@types/md5": "^2.3.5",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.18.126",
+        "@types/node": "^20.19.43",
         "@types/vscode": "1.75.0",
         "@types/xml2js": "^0.4.14",
         "@types/yauzl": "^3.4.0",
@@ -483,11 +483,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/vscode": {
       "version": "1.75.0",
@@ -3308,6 +3311,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4152,10 +4162,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "dev": true
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/vscode": {
       "version": "1.75.0",
@@ -6145,6 +6158,12 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@types/lodash": "^4.17.25",
     "@types/md5": "^2.3.5",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.18.126",
+    "@types/node": "^20.19.43",
     "@types/vscode": "1.75.0",
     "@types/xml2js": "^0.4.14",
     "@types/yauzl": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@types/lodash": "^4.17.25",
     "@types/md5": "^2.3.5",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.18.104",
+    "@types/node": "^16.18.126",
     "@types/vscode": "1.75.0",
     "@types/xml2js": "^0.4.14",
     "@types/yauzl": "^3.4.0",
@@ -195,7 +195,7 @@
     "mocha": "^11.8.0",
     "ts-loader": "^9.6.2",
     "tslint": "^6.1.3",
-    "typescript": "^4.8.4",
+    "typescript": "^5.9.3",
     "webpack": "^5.105.4",
     "webpack-cli": "^4.10.0"
   },


### PR DESCRIPTION
## Summary
- Upgrade the TypeScript manifest range from `^4.8.4` (previously resolved to 4.9.5) to `^5.9.3`.
- Align `@types/node` with the declared Node.js 20 minimum by upgrading it from `^16.18.104` to `^20.19.43`.
- Supersede [Dependabot PR #297](https://github.com/microsoft/vscode-spring-initializr/pull/297), since TypeScript 7 does not provide the compiler API required by TSLint and `ts-loader`; both linting and compilation fail with 7.0.2.

## Validation
- `npm run tslint`
- `npm run compile`
- `npx --yes @vscode/vsce package`
- `npm test` - 2 passing
- `npm audit --omit=dev` - 0 vulnerabilities
- Full audit findings are unchanged from `main`