### PR TITLE
fix(deps): update js-yaml to resolve Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1885,10 +1885,21 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3162,10 +3173,11 @@
       }
     },
     "node_modules/tslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5046,9 +5058,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -5912,9 +5924,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+          "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",


### PR DESCRIPTION
## Summary

Resolve all six currently open Dependabot alerts with a compatible, development-only [package-lock.json](https://github.com/microsoft/vscode-spring-initializr/blob/71c4a5918925e6fb181929a03e3657fc2f1bd26a/package-lock.json) update:

- Update TSLint's `js-yaml` from **3.14.2 to 3.15.2**, within its existing `^3.13.1` constraint.
- Update the shared Mocha/webpack-cli `js-yaml` from **4.1.1 to 4.3.2**, within Mocha's existing `^4.1.0` constraint and webpack-cli's optional peer constraint.
- Preserve lockfile version 2 and its matching legacy dependency entries. Only these two resolved package records change, including npm-provided license/funding metadata. [package.json](https://github.com/microsoft/vscode-spring-initializr/blob/71c4a5918925e6fb181929a03e3657fc2f1bd26a/package.json), runtime code, and all other resolved dependencies remain unchanged.

The patched releases satisfy the existing dependency constraints, so overrides and unrelated major upgrades are unnecessary. Generated using `npm update js-yaml --package-lock-only --lockfile-version=2 --ignore-scripts --no-fund`.

## Alerts addressed

| Dependabot alert | Severity | Advisory | First patched version | Resolved version |
| --- | --- | --- | --- | --- |
| [73](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/73) | High | [GHSA-5p4m-2wfm-xmqj — ordered maps](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | 3.15.1 | 3.15.2 |
| [72](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/72) | High | [GHSA-5p4m-2wfm-xmqj — ordered maps](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | 4.3.1 | 4.3.2 |
| [63](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/63) | High | [GHSA-52cp-r559-cp3m — merge chains](https://github.com/advisories/GHSA-52cp-r559-cp3m) | 4.3.0 | 4.3.2 |
| [62](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/62) | High | [GHSA-52cp-r559-cp3m — merge chains](https://github.com/advisories/GHSA-52cp-r559-cp3m) | 3.15.0 | 3.15.2 |
| [59](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/59) | Medium | [GHSA-h67p-54hq-rp68 — repeated aliases](https://github.com/advisories/GHSA-h67p-54hq-rp68) | 3.15.0 | 3.15.2 |
| [58](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/58) | Medium | [GHSA-h67p-54hq-rp68 — repeated aliases](https://github.com/advisories/GHSA-h67p-54hq-rp68) | 4.2.0 | 4.3.2 |

No alerts are manually dismissed; GitHub should resolve these alerts after this change reaches the default branch.

## Validation

The unchanged fix commit was validated locally on Windows with Node.js 22.15.1 and npm 10.9.2:

- `npm ci --no-fund`
- `npm run tslint`
- `npm test` — development webpack build, TypeScript compilation, and both extension tests passed against VS Code 1.136.1.
- `npm run vscode:prepublish` — production build passed.
- `npm audit --audit-level=moderate` — passed; only pre-existing low-severity findings remain.
- Programmatic semver assertions confirmed that every resolved `js-yaml` copy is outside all six vulnerable ranges, still satisfies its parent constraints, matches the v2 legacy entries, and is part of a graph delta limited to the two intended package records.

## Existing audit exceptions

`npm audit` is **not completely clean**: existing low-severity `diff`/Mocha findings remain unchanged. GitHub's corresponding `diff` alerts [32](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/32) and [50](https://github.com/microsoft/vscode-spring-initializr/security/dependabot/50) are already `auto_dismissed`, not open alerts. An unrelated forced Mocha upgrade is intentionally outside this fix.