### PR TITLE
chore(deps): limit npm version updates to minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # CI restores packages from the Central Feed Service, which withholds
     # upstream versions until they are roughly a week old (measured at ~6.8
     # days; both the packument entry and the tarball return 404 before then).
@@ -24,5 +27,8 @@ updates:
         patterns: ["*"]
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 7
+      default-days: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,5 @@ updates:
         patterns: ["*"]
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     cooldown:
-      default-days: 10
+      default-days: 7


### PR DESCRIPTION
Updates only the `npm` entry (directory `/`) in [`.github/dependabot.yml`](https://github.com/microsoft/vscode-spring-initializr/blob/b6a2b59468915c9388c6acfc559807eaccdd5457/.github/dependabot.yml) to ignore `version-update:semver-major` for `dependency-name: "*"`, limiting routine npm version updates to minor and patch releases.

Retains npm's existing daily schedule and universal `cooldown.default-days: 10`. The GitHub Actions entry is unchanged from the original base: weekly grouped updates with its existing 7-day cooldown and no major-version ignore. No dependency versions, lockfiles, or unrelated settings change.

The cooldown measures release age for version updates only; it does not delay security updates, and security settings are unchanged.

Validation: the existing `js-yaml` parser confirms the Actions entry matches the original base, npm retains its wildcard major ignore and universal 10-day cooldown, and all unrelated settings are preserved. `npm test` passes (2 tests).