### PR TITLE
build: validate dependency updates through CFS

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -69,6 +69,10 @@ extends:
             steps:
               - checkout: self
                 fetchTags: true
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
               - template: /.azure-pipelines/npm-cfs.yml@self
               - script: npm install
                 displayName: 'npm install'

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -16,6 +16,17 @@ trigger:
   branches:
     include:
       - main
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - package.json
+      - package-lock.json
+      - .azure-pipelines/ci.yml
+      - .azure-pipelines/npm-cfs.yml
+      - .azure-pipelines/npm-cfs-variables.yml
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -33,8 +44,22 @@ extends:
     stages:
       - stage: Build
         jobs:
+          - job: CFSValidation
+            displayName: Validate dependencies from CFS
+            condition: eq(variables['Build.Reason'], 'PullRequest')
+            steps:
+              - checkout: self
+                fetchTags: false
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
+              - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
+                displayName: Validate npm dependencies from CFS
           - job: Job_1
             displayName: Agent job 1
+            condition: ne(variables['Build.Reason'], 'PullRequest')
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -19,6 +19,7 @@ resources:
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
 trigger: none
+pr: none
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    # CI restores packages from the Central Feed Service, which withholds
-    # upstream versions until they are roughly a week old (measured at ~6.8
-    # days; both the packument entry and the tarball return 404 before then).
-    # Dependabot's built-in cooldown is only 3 days, so bumps otherwise land in
-    # a window where the feed 404s and the build fails. 10 days leaves margin
-    # in case the feed's ingestion lag drifts.
-    cooldown:
-      default-days: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:


### PR DESCRIPTION
## Summary
- remove scheduled npm Dependabot version updates while keeping grouped GitHub Actions updates
- add PR validation for npm dependency and CFS pipeline configuration changes
- restore `package-lock.json` through CFS with an isolated npm cache
- pin Node 20 for both PR validation and full CI builds
- keep the existing full build and VSIX packaging for non-PR runs
- keep release pipelines manual-only and disable their GitHub status reporting

## ADO
- re-enabled [`microsoft.vscode-spring-initializr.ci`](https://dev.azure.com/mseng/VSJava/_build?definitionId=14224), switched it to the `microsoft (7)` GitHub connection, and enabled automatic PR validation
- disabled GitHub status reporting for the manual `release` and `release-nightly` definitions

## Validation
- compiled the CI pipeline through the Azure Pipelines Preview API
- parsed the updated YAML files
- ran `npm ci --ignore-scripts`